### PR TITLE
rework of `show_dislocation` and `interactive_view` for miltispicies

### DIFF
--- a/docs/applications/multispecies_dislocations.ipynb
+++ b/docs/applications/multispecies_dislocations.ipynb
@@ -20,7 +20,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b74ce6c53ac44fbe9fa788ba2d3c4d11",
+       "model_id": "6cc861df79b54fbf909fa969614e99ec",
        "version_major": 2,
        "version_minor": 0
       },
@@ -57,7 +57,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "11305ef38e2e4ecfa54d6b1159afbe5e",
+       "model_id": "bc75df5c1d5b48bd8dd8dd3930e32c46",
        "version_major": 2,
        "version_minor": 0
       },
@@ -70,10 +70,11 @@
     }
    ],
    "source": [
+    "import nglview # this import is necessary for rendering of the 3D view\n",
+    "import numpy as np\n",
     "from ase.build import bulk\n",
     "from ase.lattice.cubic import Diamond\n",
-    "import numpy as np\n",
-    "from visualisation import interactive_view\n",
+    "from visualisation import interactive_view, show_dislocation\n",
     "\n",
     "# Data from https://pubs.acs.org/doi/epdf/10.1021/acs.jpca.0c02450 DFT values\n",
     "alat = 5.84\n",
@@ -117,7 +118,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "de619fb72c4a4892a6248958d1900800",
+       "model_id": "4bdc430bd82a4c8fbdc2e1fa48878f1c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -136,7 +137,9 @@
     "\n",
     "InP_bulk, InP_dislocation = disloc.build_cylinder(radius=3 * alat)\n",
     "\n",
-    "interactive_view(InP_dislocation, scale=0.3)"
+    "show_dislocation(InP_dislocation, scale=0.2, \n",
+    "                 diamond_structure=True, \n",
+    "                 CNA_color=False, add_bonds=True)"
    ]
   },
   {
@@ -151,13 +154,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c62a2a66af5d4b0a9cd2b2f44fdafc18",
+       "model_id": "f48a5c1daa2c49cfa7d319bd4bad5936",
        "version_major": 2,
        "version_minor": 0
       },
@@ -181,7 +184,9 @@
     "disloc = DiamondGlide90degreePartial(InP, C11, C12, C44)\n",
     "\n",
     "InP_bulk, InP_dislocation = disloc.build_cylinder(radius=3 * alat)\n",
-    "interactive_view(InP_dislocation, scale=0.3)"
+    "show_dislocation(InP_dislocation, scale=0.2, \n",
+    "                 diamond_structure=True, d_name=\"alpha-90 degree partial\",\n",
+    "                 CNA_color=False, add_bonds=True)"
    ]
   },
   {
@@ -199,7 +204,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6f7c7096b6a645778d8cdd9a56810eb1",
+       "model_id": "8cffe25a8ec94efb97e200090f799bd9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -217,7 +222,9 @@
     "disloc = DiamondGlide90degreePartial(InP, C11, C12, C44)\n",
     "\n",
     "InP_bulk, InP_dislocation = disloc.build_cylinder(radius=3 * alat)\n",
-    "interactive_view(InP_dislocation, scale=0.3)"
+    "show_dislocation(InP_dislocation, scale=0.2, \n",
+    "                 diamond_structure=True,\n",
+    "                 CNA_color=False, add_bonds=True)"
    ]
   },
   {
@@ -248,7 +255,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6885164040f4514916f7e79abdbd518",
+       "model_id": "42201125b1af48f2ba6310146f3aa96e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -277,7 +284,9 @@
     "\n",
     "GaAs_bulk, GaAs_dislocation = disloc.build_cylinder(radius=3 * alat)\n",
     "\n",
-    "interactive_view(GaAs_dislocation, scale=0.3)"
+    "show_dislocation(GaAs_dislocation, scale=0.2, \n",
+    "                 diamond_structure=True,\n",
+    "                 CNA_color=False, add_bonds=True)"
    ]
   },
   {
@@ -295,7 +304,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f0cdfef9d07485f8e19962a5cdbf77c",
+       "model_id": "5cde9dffd58942fc9020c1fda4d2186a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -328,15 +337,18 @@
     "InGaAs_dislocation = GaAs_dislocation.copy()\n",
     "InGaAs_dislocation.set_chemical_symbols(species)\n",
     "\n",
-    "interactive_view(InGaAs_dislocation, scale=0.3)"
+    "view = show_dislocation(InGaAs_dislocation, scale=0.2,\n",
+    "                        diamond_structure=True,\n",
+    "                        CNA_color=False, add_bonds=True)\n",
+    "\n",
+    "# In and Ga have almost the same default colors in nglview,\n",
+    "# so we add another component with the In atoms in red to\n",
+    "# see the chemical disorder better\n",
+    "c = view.add_component(nglview.ASEStructure(InGaAs_dislocation[In_idxs]), \n",
+    "                                            default_representaion=False)\n",
+    "c.add_spacefill(radius=0.6, color=\"red\")\n",
+    "view"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/applications/multispecies_dislocations.ipynb
+++ b/docs/applications/multispecies_dislocations.ipynb
@@ -14,9 +14,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b74ce6c53ac44fbe9fa788ba2d3c4d11",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -45,7 +57,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "924d9db01388446a8a365bc71d3cedab",
+       "model_id": "11305ef38e2e4ecfa54d6b1159afbe5e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -99,13 +111,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36e1816ef96d47a8b5be25662ed81182",
+       "model_id": "de619fb72c4a4892a6248958d1900800",
        "version_major": 2,
        "version_minor": 0
       },
@@ -139,13 +151,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "905198641fdb4211bfe428bd85f7a203",
+       "model_id": "c62a2a66af5d4b0a9cd2b2f44fdafc18",
        "version_major": 2,
        "version_minor": 0
       },
@@ -181,13 +193,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f0e414a01654e9bbb5786428c48604c",
+       "model_id": "6f7c7096b6a645778d8cdd9a56810eb1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -236,7 +248,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "beac300a4ed443d3a3676d20373de816",
+       "model_id": "c6885164040f4514916f7e79abdbd518",
        "version_major": 2,
        "version_minor": 0
       },
@@ -283,7 +295,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6c92a85910c4df1bbbd3f5c945e5d5c",
+       "model_id": "5f0cdfef9d07485f8e19962a5cdbf77c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -318,6 +330,13 @@
     "\n",
     "interactive_view(InGaAs_dislocation, scale=0.3)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -336,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/applications/visualisation.py
+++ b/docs/applications/visualisation.py
@@ -45,6 +45,31 @@ def get_structure_types(structure, diamond_structure=False):
 # interactive visualisation  inside the notebook with nglview
 from nglview import show_ase, ASEStructure
 
+# custom tooltip for nglview to avoid showing molecule and residue names
+# that are not relevant for our type of structures
+tooltip_js = """
+                this.stage.mouseControls.add('hoverPick', (stage, pickingProxy) => {
+                    let tooltip = this.stage.tooltip;
+                    if(pickingProxy && pickingProxy.atom && !pickingProxy.bond){
+                        let atom = pickingProxy.atom;
+                        if (atom.structure.name.length > 0){
+                            tooltip.innerText = atom.atomname + " atom: " + atom.structure.name;
+                        } else {
+                            tooltip.innerText = atom.atomname + " atom";
+                        }
+                    } else if (pickingProxy && pickingProxy.bond){
+                        let bond = pickingProxy.bond;
+                        if (bond.structure.name.length > 0){
+                        tooltip.innerText = bond.atom1.atomname + "-" + bond.atom2.atomname + " bond: " + bond.structure.name;
+                        } else {
+                            tooltip.innerText = bond.atom1.atomname + "-" + bond.atom2.atomname + " bond";
+                        }
+                    } else if (pickingProxy && pickingProxy.unitcell){
+                        tooltip.innerText = "Unit cell";
+                    }
+                });
+                """
+
 def add_dislocation(view, system, name, color=[0, 1, 0], x_shift=0.0):
     '''Add dislocation line to the view as a cylinder and two cones.
     The cylinder is hollow by default so the second cylinder is needed to close it.
@@ -111,30 +136,18 @@ def show_dislocation(system, scale=0.5, diamond_structure=False, add_bonds=False
 
     view._remote_call("setSize", target="Widget", args=["700px", "400px"])
     view.center()
-    
-    tooltip_js = """
-                 this.stage.mouseControls.add('hoverPick', (stage, pickingProxy) => {
-                        let tooltip = this.stage.tooltip;
-                        if(pickingProxy && pickingProxy.atom && !pickingProxy.bond){
-                            let atom = pickingProxy.atom;
-                            tooltip.innerText = atom.atomname + " atom: " + atom.structure.name;
-                        } else if (pickingProxy && pickingProxy.bond){
-                            let bond = pickingProxy.bond;
-                            tooltip.innerText = bond.atom1.atomname + "-" + bond.atom2.atomname + " bond: " + bond.structure.name;
-                        } else if (pickingProxy && pickingProxy.unitcell){
-                            tooltip.innerText = "Unit cell";
-                        }
-                    });
-                 """
+
     view._js(tooltip_js)
     return view
 
 
-def interactive_view(system, scale=0.5):
+def interactive_view(system, scale=0.5, name=""):
     view = show_ase(system)
     view._remove_representation()
+    component = view.add_component(ASEStructure(system), 
+                                   default_representation=False, name=name)
+    component.add_spacefill(radiusType='covalent', radiusScale=scale)
     view.add_unitcell()
-    view.add_spacefill()
     view.update_spacefill(radiusType='covalent',
                           radiusScale=scale)
 
@@ -143,4 +156,5 @@ def interactive_view(system, scale=0.5):
 
     view.center()
     view._remote_call("setSize", target="Widget", args=["300px", "300px"])
+    view._js(tooltip_js)
     return view

--- a/docs/applications/visualisation.py
+++ b/docs/applications/visualisation.py
@@ -96,7 +96,7 @@ def add_dislocation(view, system, name, color=[0, 1, 0], x_shift=0.0):
                         name)
     
 
-def show_dislocation(system, scale=0.5, diamond_structure=False, add_bonds=False,
+def show_dislocation(system, scale=0.5, CNA_color=True, diamond_structure=False, add_bonds=False,
                      d_name='', d_color=[0, 1, 0], partial_distance=None):
 
     atom_labels, structure_names, colors = get_structure_types(system, 
@@ -114,11 +114,17 @@ def show_dislocation(system, scale=0.5, diamond_structure=False, add_bonds=False
         mask = atom_labels == structure_type
         component = view.add_component(ASEStructure(system[mask]), 
                                        default_representation=False, name=str(structure_names[structure_type]))
-        if add_bonds:
-            component.add_ball_and_stick(color=colors[structure_type], radiusType='covalent', radiusScale=scale)
+        if CNA_color:
+            if add_bonds:
+                component.add_ball_and_stick(color=colors[structure_type], radiusType='covalent', radiusScale=scale)
+            else:
+                component.add_spacefill(color=colors[structure_type], radiusType='covalent', radiusScale=scale)
         else:
-            component.add_spacefill(color=colors[structure_type], radiusType='covalent', radiusScale=scale)
-        
+            if add_bonds:
+                component.add_ball_and_stick(radiusType='covalent', radiusScale=scale)
+            else:
+                component.add_spacefill(radiusType='covalent', radiusScale=scale)
+                    
     component.add_unitcell()
 
     if partial_distance is None:


### PR DESCRIPTION
- updated tooltip for `interactive_view` 
- added `CNA_color` to `show_dislocation`
- added an ad-hock way to change color of In atoms just by adding larger read atoms. 

You will have to add `d_name` to `show_dislocation` so the name is correctly picked up by the tooltip.

Keep in mind that sometimes if you notebook has all the outputs it will not be run automaticaly and thus the visualisations will not render. In this case just remove an output of any cell. 