### PR TITLE
DOCs: final touches for the documentaion.

### DIFF
--- a/docs/applications/gamma_surface_advanced.ipynb
+++ b/docs/applications/gamma_surface_advanced.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10,7 +10,8 @@
     "from IPython.display import HTML\n",
     "def show_HTML(anim):\n",
     "    '''\n",
-    "    Convert matplotlib.animation.FuncAnimation (e.g. from GammaSurface.show()) to HTML viewable object.\n",
+    "    Convert matplotlib.animation.FuncAnimation \n",
+    "    (e.g. from GammaSurface.show()) to HTML viewable object.\n",
     "\n",
     "    anim: matplotlib.animation.FuncAnimation object\n",
     "        Animation to convert to HTML\n",
@@ -43,14 +44,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "494d2a96639e465ca08b7d4510745621",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "alat = 3.360528114483162\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "068b8453542a4b0f98a970b03a58213b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NGLWidget()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from matscipy.dislocation import DiamondGlideScrew, get_elastic_constants\n",
     "from matscipy.gamma_surface import StackingFault\n",
-    "from matscipy.calculators.manybody.explicit_forms.tersoff_brenner import TersoffBrenner, \\\n",
-    "                                                                         Brenner_PRB_42_9458_C_I\n",
+    "from matscipy.calculators.manybody.explicit_forms.tersoff_brenner import \\\n",
+    "                                   TersoffBrenner, Brenner_PRB_42_9458_C_I\n",
     "from matscipy.calculators.manybody import Manybody\n",
     "from visualisation import show_dislocation\n",
     "\n",
@@ -160,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/applications/gamma_surface_advanced.ipynb
+++ b/docs/applications/gamma_surface_advanced.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,44 +44,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "494d2a96639e465ca08b7d4510745621",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "alat = 3.360528114483162\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "068b8453542a4b0f98a970b03a58213b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "NGLWidget()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
+    "import numpy as np\n",
     "from matscipy.dislocation import DiamondGlideScrew, get_elastic_constants\n",
     "from matscipy.gamma_surface import StackingFault\n",
     "from matscipy.calculators.manybody.explicit_forms.tersoff_brenner import \\\n",
@@ -104,6 +71,7 @@
     "                 partial_distance=20 * C_screw.glide_distance, \n",
     "                 d_name=\"1/6<112> 30 degree partial screw\") \n",
     "\n",
+    "view.control.spin([0, 1, 0], np.math.pi) # flip along y-axis to align with SF visualisation\n",
     "view.control.zoom(0.7)\n",
     "view"
    ]
@@ -112,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will use the `StackingFault` class to try and model the stacking fault we see in the above dissociated dislocation plot. The plot made use of [Common Neighbour Analysis (CNA)](https://www.ovito.org/docs/current/reference/pipelines/modifiers/common_neighbor_analysis.html) to provide useful colours for the atoms. This is also available in the `.show()` methods of the `StackingFault` and `GammaSurface` classes, using the `CNA_color=True` argument."
+    "We will use the `StackingFault` class to try and model the stacking fault we see in the above dissociated dislocation plot. The plot made use of [Common Neighbour Analysis (CNA)](https://www.ovito.org/docs/current/reference/pipelines/modifiers/common_neighbor_analysis.html) to provide useful colours for the atoms according to the identified crystal structure. This is also available in the `.show()` methods of the `StackingFault` and `GammaSurface` classes, using the `CNA_color=True` argument."
    ]
   },
   {
@@ -122,7 +90,7 @@
    "outputs": [],
    "source": [
     "fault = StackingFault(alat, DiamondGlideScrew, symbol=\"C\")\n",
-    "fault.generate_images(n=8, cell_move=False, z_reps=2, vacuum=True)\n",
+    "fault.generate_images(n=9, cell_move=False, z_reps=2, vacuum=True)\n",
     "anim = fault.show(CNA_color=True)\n",
     "show_HTML(anim)"
    ]
@@ -131,7 +99,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that CNA gives the same orange colour we see in the dislocation part way through the stacking fault sweep. This helps to confirm that we have generated a similar local structure.\n",
+    "We can see that CNA gives the same orange colour we see in the dislocation part way through the stacking fault sweep. With nine total images along the path, the middle image number five corresponds to the perfect stacking fault structure. It can be seen that atomic stacking of image five is exactly the same as the stacking fault region between two partial dislocations. This helps to confirm that we have generated a similar local structure.\n",
     "\n",
     "## Accessing Different Stacking Fault Planes\n",
     "The Diamond (111) surface is interesting, as it has two distinct planes, called \"glide\" and \"shuffle\", with the same (111) normal direction. Selection of which plane you are modelling depends on which z ordinate in the crystal basis you choose to cut at. Because in the previous example we parameterised the stacking fault with `DiamondGlideScrew` (which is a dislocation along the glide plane, as the name would suggest), we achieved a stacking fault on the glide plane. To achieve the related stacking fault on the shuffle plane, we can use the argument `z_offset` to add an offset (in Angstrom) and shift to the different plane. For this carbon crystal, an offset of 0.84 Angstrom gets us to the shuffle plane."
@@ -144,7 +112,7 @@
    "outputs": [],
    "source": [
     "fault = StackingFault(alat, DiamondGlideScrew, symbol=\"C\")\n",
-    "fault.generate_images(n=8, cell_move=False, z_reps=2, z_offset=0.84, vacuum=True)\n",
+    "fault.generate_images(n=9, cell_move=False, z_reps=2, z_offset=0.84, vacuum=True)\n",
     "anim = fault.show(CNA_color=True)\n",
     "show_HTML(anim)"
    ]
@@ -175,7 +143,7 @@
     "GaAs = bulk(\"GaAs\", crystalstructure=\"zincblende\", cubic=True, a=alat)\n",
     "\n",
     "fault = StackingFault(GaAs, DiamondGlideScrew)\n",
-    "fault.generate_images(n=8, cell_move=False, z_reps=2, vacuum=True)\n",
+    "fault.generate_images(n=9, cell_move=False, z_reps=2, vacuum=True)\n",
     "anim = fault.show(CNA_color=False)\n",
     "show_HTML(anim)"
    ]

--- a/docs/applications/gamma_surface_advanced.ipynb
+++ b/docs/applications/gamma_surface_advanced.ipynb
@@ -112,7 +112,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will use the `StackingFault` class to try and model the stacking fault we see in the above dissociated dislocation plot. The plot made use of sCommon Neighbour Analysis (CNA) to provide useful colours for the atoms. This is also available in the `.show()` methods of the `StackingFault` and `GammaSurface` classes, using the `CNA_color=True` arg."
+    "We will use the `StackingFault` class to try and model the stacking fault we see in the above dissociated dislocation plot. The plot made use of [Common Neighbour Analysis (CNA)](https://www.ovito.org/docs/current/reference/pipelines/modifiers/common_neighbor_analysis.html) to provide useful colours for the atoms. This is also available in the `.show()` methods of the `StackingFault` and `GammaSurface` classes, using the `CNA_color=True` argument."
    ]
   },
   {
@@ -134,7 +134,7 @@
     "We can see that CNA gives the same orange colour we see in the dislocation part way through the stacking fault sweep. This helps to confirm that we have generated a similar local structure.\n",
     "\n",
     "## Accessing Different Stacking Fault Planes\n",
-    "The Diamond (111) surface is interesting, as it has two distinct planes, called \"glide\" and \"shuffle\", with the same (111) normal direction. Selection of which plane you are modelling depends on which z ordinate in the crystal basis you choose to cut at. Because in the previous example we parameterised the stacking fault with `DiamondGlideScrew` (which is a dislocation along the glide plane, as the name would suggest), we achieved a stacking fault on the glide plane. To achieve the related stacking fault on the shuffle plane, we can use the argument `z_offset` to add an offset (in Ang) and shift to the different plane. For this carbon crystal, an offset of 0.84Ang gets us to the shuffle plane."
+    "The Diamond (111) surface is interesting, as it has two distinct planes, called \"glide\" and \"shuffle\", with the same (111) normal direction. Selection of which plane you are modelling depends on which z ordinate in the crystal basis you choose to cut at. Because in the previous example we parameterised the stacking fault with `DiamondGlideScrew` (which is a dislocation along the glide plane, as the name would suggest), we achieved a stacking fault on the glide plane. To achieve the related stacking fault on the shuffle plane, we can use the argument `z_offset` to add an offset (in Angstrom) and shift to the different plane. For this carbon crystal, an offset of 0.84 Angstrom gets us to the shuffle plane."
    ]
   },
   {
@@ -156,7 +156,9 @@
     "## Stacking Faults in more complex systems\n",
     "`GammaSurface` and `StackingFault` generate a base structure from the input arguments in a very similar manner to the dislocation classes in `matscipy.dislocation`. This means that instead of supplying a lattice constant + symbol + crystalstructure, we can instead pass an atoms object. As an example, lets revisit GaAs from the multispecies dislocation docs:\n",
     "\n",
-    "NOTE: As with the dislocation classes, `GammaSurface` and `StackingFault` are only guaranteed to work when passed cubic bulk crystals, and cannot themselves model chemical disorder. Any disorder effects should be applied after `generate_images()` is called."
+    ":::{note}\n",
+    "As with the dislocation classes, `GammaSurface` and `StackingFault` are only guaranteed to work when passed cubic bulk crystals, and cannot themselves model chemical disorder. Any disorder effects should be applied after `generate_images()` is called.\n",
+    ":::"
    ]
   },
   {

--- a/docs/applications/gamma_surfaces.ipynb
+++ b/docs/applications/gamma_surfaces.ipynb
@@ -45,17 +45,29 @@
     "The first and most intuitive method involves splitting a supercell of this rotated structure into an upper and lower slab, and translating the top slab relative to the bottom. In the fully periodic case, this creates two stacking faults in the cell, at both the upper and lower boundaries of the top slab. We could instead choose to leave free surfaces above the top slab and below the bottom slab by removing the periodicity in the direction of the surface normal, which leaves us with a single gamma surface between the slabs.\n",
     "\n",
     "## Method 2 - \"Cell Move\" Method\n",
-    "The second method method is more efficient as it reduces the number of atoms required, but is less intuitive to understand. Instead of moving atoms, we modify the cell vectors without moving the atoms. In doing this, we translate the periodic image of the bottom of the structure relative to the top of the structure, and vice versa, thus skipping the need to have two slabs. This method always produces a structure containing a single gamma surface, which is always at the cell boundaries. In order to model the free-surface approach, we can add vacuum to the center of the cell, which creates a similar two slab setup as method 1, but this time in a periodic cell.\n",
-    "\n",
-    "NOTE: `GammaSurface` and `StackingFault` are extremely closely related as classes. To avoid these docs from becoming an API reference, lots of the additional features are spread across all examples. Though basic usage of the code can be achieved purely by copying the first example, the recommendation is to have a quick glance at all examples in order to see how the code may be parametised to suit your needs.\n",
-    "\n",
+    "The second method method is more efficient as it reduces the number of atoms required, but is less intuitive to understand. Instead of moving atoms, we modify the cell vectors without moving the atoms. In doing this, we translate the periodic image of the bottom of the structure relative to the top of the structure, and vice versa, thus skipping the need to have two slabs. This method always produces a structure containing a single gamma surface, which is always at the cell boundaries. In order to model the free-surface approach, we can add vacuum to the center of the cell, which creates a similar two slab setup as method 1, but this time in a periodic cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{note}\n",
+    "`GammaSurface` and `StackingFault` are extremely closely related as classes. To avoid these docs from becoming an API reference, lots of the additional features are spread across all examples. Though basic usage of the code can be achieved purely by copying the first example, the recommendation is to have a quick glance at all examples in order to see how the code may be parametised to suit your needs.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Gamma Surface Example using Method 1\n",
     "We will start with a very basic gamma surface, using the example of the (100) surface in FCC Aluminium, using the first method described above. We will use a model by [Kioseoglou et al](https://doi.org/10.1002/pssb.200844122) in order to perform some relaxations, and see what the surface looks like."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +97,9 @@
    "source": [
     "To generate some stacking fault images, we use `GammaSurface.generate_images`. We will then use `GammaSurface.show()` to construct a nice `matplotlib.animation.FuncAnimation` showing the surface. We will also disable the periodicity in z to create free surfaces, which can be done via setting `vacuum=True`.\n",
     "\n",
-    "NOTE: The argument `vacuum` works differently depending on if you are using Method 1 (`cell_move=False`) or Method 2 (`cell_move=True`). For Method 1, `vacuum` toggles the periodicity in z on (`vacuum=False`) or off (`vacuum=True`), whereas for Method 2 is should be a float which gives the thickness of a vacuum layer to add in the center of the cell (between the periodic images of the gamma surfaces)."
+    ":::{note}\n",
+    "The argument `vacuum` works differently depending on if you are using Method 1 (`cell_move=False`) or Method 2 (`cell_move=True`). For Method 1, `vacuum` toggles the periodicity in z on (`vacuum=False`) or off (`vacuum=True`), whereas for Method 2 is should be a float which gives the thickness of a vacuum layer to add in the center of the cell (between the periodic images of the gamma surfaces).\n",
+    ":::"
    ]
   },
   {
@@ -188,41 +202,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "RuntimeError",
-     "evalue": "Cannot plot energy densities before get_energy_densities is called!",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
-      "File \u001b[0;32m~/anaconda3/envs/quippy-ase/lib/python3.9/site-packages/matscipy/gamma_surface.py:531\u001b[0m, in \u001b[0;36mGammaSurface.show\u001b[0;34m(self, CNA_color, plot_energies, si, **kwargs)\u001b[0m\n\u001b[1;32m    529\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[1;32m    530\u001b[0m     \u001b[39m# Assume that calculator is attached so we can get energy densities\u001b[39;00m\n\u001b[0;32m--> 531\u001b[0m     Es \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mget_energy_densities()\n\u001b[1;32m    532\u001b[0m \u001b[39mexcept\u001b[39;00m:\n",
-      "File \u001b[0;32m~/anaconda3/envs/quippy-ase/lib/python3.9/site-packages/matscipy/gamma_surface.py:376\u001b[0m, in \u001b[0;36mGammaSurface.get_energy_densities\u001b[0;34m(self, calculator, relax, **relax_kwargs)\u001b[0m\n\u001b[1;32m    374\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mRuntimeError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mNo calculator supplied for energy evaluation\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 376\u001b[0m cell \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mimages[\u001b[39m0\u001b[39;49m]\u001b[39m.\u001b[39mcell[:, :]\n\u001b[1;32m    377\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39msurface_area \u001b[39m=\u001b[39m np\u001b[39m.\u001b[39mlinalg\u001b[39m.\u001b[39mnorm(np\u001b[39m.\u001b[39mcross(cell[\u001b[39m0\u001b[39m, :], cell[\u001b[39m1\u001b[39m, :]))\n",
-      "\u001b[0;31mIndexError\u001b[0m: list index out of range",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[1;32m/home/petr/gits/matscipy/docs/applications/gamma_surfaces.ipynb Cell 15\u001b[0m line \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/petr/gits/matscipy/docs/applications/gamma_surfaces.ipynb#X42sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m anim \u001b[39m=\u001b[39m surface\u001b[39m.\u001b[39;49mshow(plot_energies\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m, si\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m)\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/petr/gits/matscipy/docs/applications/gamma_surfaces.ipynb#X42sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m show_HTML(anim)\n",
-      "File \u001b[0;32m~/anaconda3/envs/quippy-ase/lib/python3.9/site-packages/matscipy/gamma_surface.py:533\u001b[0m, in \u001b[0;36mGammaSurface.show\u001b[0;34m(self, CNA_color, plot_energies, si, **kwargs)\u001b[0m\n\u001b[1;32m    531\u001b[0m             Es \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mget_energy_densities()\n\u001b[1;32m    532\u001b[0m         \u001b[39mexcept\u001b[39;00m:\n\u001b[0;32m--> 533\u001b[0m             \u001b[39mraise\u001b[39;00m \u001b[39mRuntimeError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mCannot plot energy densities before get_energy_densities is called!\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    535\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mplot_energy_densities(ax\u001b[39m=\u001b[39menergy_ax, si\u001b[39m=\u001b[39msi)\n\u001b[1;32m    536\u001b[0m \u001b[39melse\u001b[39;00m:\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: Cannot plot energy densities before get_energy_densities is called!"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD8CAYAAAB6paOMAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAWpUlEQVR4nO3df6xf9V3H8efLsiaukjGlw1lAq6ljzIyEfS24LRtomC26NEv4ozglISRNzTDqH4tEk+mfmv2zTJGmIQ3ZH6P/bMyawGDRKIuI660p0BJZLt2Ua0koP8IiM2Lx7R/nkH53ey/33Pv9cQrn+Ui+6fec8znf9znt69v3Pd/vOfekqpAkDdeP9b0BkqR+2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGbs1GkORQkheSnFhleZJ8OclikieTXDu2bFeSZ9pld01zw6VJmW2p0eWI4D5g11ss3w3saB/7gHsAkmwC7m6XXw3cmuTqSTZWmrL7MNvS2o2gqh4FXn6LIXuAr1TjceCSJO8HdgKLVXWqql4HDrdjpQuC2ZYaF03hNbYBz41NL7XzVpp/3WovkmQfzU9dbNmy5SNXXXXVFDZNOt+xY8derKqtHYZOnG1zrXlZR67PM41GkBXm1VvMX1FVHQQOAoxGo1pYWJjCpknnS/LvXYeuMG9d2TbXmpd15Po802gES8AVY9OXA6eBzavMl94uzLYGYRqnjx4BbmvPsLgeeLWqngeOAjuSbE+yGdjbjpXeLsy2BmHNI4Ik9wM3AJcmWQL+FHgXQFUdAB4EbgYWgR8Ct7fLzia5E3gY2AQcqqqTM9gHaUPMttRYsxFU1a1rLC/gc6sse5DmzSRdcMy21PDKYkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHCdGkGSXUmeSbKY5K4Vln8+yfH2cSLJG0l+sl32/SRPtcu8c7cuGOZaanS5VeUm4G7gJpqbeR9NcqSqnn5zTFV9EfhiO/7TwB9W1ctjL3NjVb041S2XJmCupXO6HBHsBBar6lRVvQ4cBva8xfhbgfunsXHSDJlrqdWlEWwDnhubXmrnnSfJu4FdwNfGZhfwSJJjSfatViTJviQLSRbOnDnTYbOkiZhrqdWlEWSFebXK2E8D/7Ts8PljVXUtsBv4XJJPrLRiVR2sqlFVjbZu3dphs6SJmGup1aURLAFXjE1fDpxeZexelh0+V9Xp9s8XgAdoDsmlvplrqdWlERwFdiTZnmQzzZviyPJBSd4DfBL4m7F5W5Jc/OZz4FPAiWlsuDQhcy211jxrqKrOJrkTeBjYBByqqpNJ9rfLD7RDPwM8UlWvja1+GfBAkjdrfbWqvjnNHZA2wlxL56RqtY9F+zMajWphwVOzNRtJjlXVaN51zbVmaZJce2WxJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkauE6NIMmuJM8kWUxy1wrLb0jyapLj7eMLXdeV+mKupcaat6pMsgm4G7iJ5obfR5Mcqaqnlw39dlX95gbXlebKXEvndDki2AksVtWpqnodOAzs6fj6k6wrzZK5llpdGsE24Lmx6aV23nK/kuSJJA8l+dA61yXJviQLSRbOnDnTYbOkiZhrqdWlEWSFecvveP+vwM9W1TXAXwLfWMe6zcyqg1U1qqrR1q1bO2yWNBFzLbW6NIIl4Iqx6cuB0+MDquoHVfVf7fMHgXclubTLulJPzLXU6tIIjgI7kmxPshnYCxwZH5Dkp5Okfb6zfd2Xuqwr9cRcS601zxqqqrNJ7gQeBjYBh6rqZJL97fIDwC3A7yY5C/w3sLeqClhx3Rnti9SZuZbOSZPrC8toNKqFhYW+N0PvUEmOVdVo3nXNtWZpklx7ZbEkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cJ0aQZJdSZ5JspjkrhWWfzbJk+3jsSTXjC37fpKnkhxP4i9j1wXDXEuNNe9QlmQTcDdwE829Wo8mOVJVT48N+x7wyap6Jclu4CBw3djyG6vqxSlutzQRcy2d0+WIYCewWFWnqup14DCwZ3xAVT1WVa+0k4/T3MxbupCZa6nVpRFsA54bm15q563mDuChsekCHklyLMm+1VZKsi/JQpKFM2fOdNgsaSLmWmqt+dEQkBXmrXij4yQ30rxhPj42+2NVdTrJ+4BvJfm3qnr0vBesOkhz6M1oNLrwbqSsdxpzLbW6HBEsAVeMTV8OnF4+KMmHgXuBPVX10pvzq+p0++cLwAM0h+RS38y11OrSCI4CO5JsT7IZ2AscGR+Q5Erg68DvVNV3x+ZvSXLxm8+BTwEnprXx0gTMtdRa86Ohqjqb5E7gYWATcKiqTibZ3y4/AHwB+Cngr5MAnK2qEXAZ8EA77yLgq1X1zZnsibQO5lo6J1UX3seWo9GoFhY8NVuzkeRY+x/6XJlrzdIkufbKYkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHCdGkGSXUmeSbKY5K4VlifJl9vlTya5tuu6Ul/MtdRYsxEk2QTcDewGrgZuTXL1smG7gR3tYx9wzzrWlebOXEvndDki2AksVtWpqnodOAzsWTZmD/CVajwOXJLk/R3XlfpgrqXWmjevB7YBz41NLwHXdRizreO6ACTZR/NTF8D/JDnRYdum7VLgxQHV7bN2n/v8AYaVaxjmv/PQ9vkDG12xSyPICvOW3/F+tTFd1m1mVh0EDgIkWejj5uJDq9tn7b73mQHlus/a7vN862503S6NYAm4Ymz6cuB0xzGbO6wr9cFcS60u3xEcBXYk2Z5kM7AXOLJszBHgtvYsi+uBV6vq+Y7rSn0w11JrzSOCqjqb5E7gYWATcKiqTibZ3y4/ADwI3AwsAj8Ebn+rdTts18GN7MwUDK1un7V73eeB5brP2u7z26Buqlb8aFOSNBBeWSxJA2cjkKSB660RTHJ5/xxqf7at+WSSx5JcM4+6Y+N+OckbSW6ZRt2utZPckOR4kpNJ/nEedZO8J8nfJnmirXv7lOoeSvLCauft95yvmdTuK9ddao+Nm2q2+8p1l9qzyPbMcl1Vc3/QfMH2LPDzNKfiPQFcvWzMzcBDNOdsXw/8yxxrfxR4b/t89zRqd6k7Nu7vab6ovGWO+3wJ8DRwZTv9vjnV/WPgL9rnW4GXgc1TqP0J4FrgxCrL+8zX1Gv3les+s91XrvvM9qxy3dcRwSSX98+8dlU9VlWvtJOP05wnPvO6rd8Dvga8MIWa66n9W8DXq+o/AKpqGvW71C3g4iQBfoLmzXJ20sJV9Wj7WqvpLV8zqt1XrjvVbk07233lumvtqWd7VrnuqxGsdun+esfMqva4O2g67MzrJtkGfAY4MIV666oN/CLw3iT/kORYktvmVPevgA/SXJD1FPD7VfV/U6g9jW2b1evOonZfue5Ue0bZ7ivXXWv3ke0NZavLlcWzMMnl/fOo3QxMbqR5w3x8TnW/BPxRVb3R/BAxNV1qXwR8BPg14MeBf07yeFV9d8Z1fx04Dvwq8AvAt5J8u6p+MEHdaW3brF53FrX7ynXX2l9i+tnuK9dda/eR7Q1lq69GMMnl/fOoTZIPA/cCu6vqpTnVHQGH2zfKpcDNSc5W1TfmUHsJeLGqXgNeS/IocA0wyRumS93bgT+v5gPOxSTfA64CvjNB3Wlt26xedxa1+8p119qzyHZfue5au49sbyxb0/jiZANfeFwEnAK2c+6Llg8tG/Mb/OiXHt+ZY+0raa4m/eg893nZ+PuY3pfFXfb5g8DftWPfDZwAfmkOde8B/qx9fhnwn8ClU9rvn2P1L9X6zNfUa/eV6z6z3Veu+872LHI9tTBsYGdupunKzwJ/0s7bD+xvn4fm5h/P0ny+Nppj7XuBV2gO644DC/Oou2zsVN4s66kNfJ7mDIsTwB/M6e/6Z4BH2n/jE8BvT6nu/cDzwP/S/JR0xwWUr5nU7ivXfWa7r1z3le1Z5dpfMSFJA9flVpUbvoCh60UmUh/MttTocvrofcCut1jufV31dnUfZltauxHUxi9g8L6uuqCZbakxjdNHJ76vK/zovV23bNnykauuumoKmyad79ixYy9W1dYOQ6d6z2JzrVlaR67PM41GMPF9XeFH7+06Go1qYWHDt9+U3lKSf+86dIV568q2uda8rCPX55lGI/C+rnqnMtsahGn8riHv66p3KrOtQVjziCDJ/cANwKVJloA/Bd4FM7uvqzQXZltqdLl5/a1rLC/gc6sse5DmzSRdcMy21PBWlZI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeA6NYIku5I8k2QxyV0rLP98kuPt40SSN5L8ZLvs+0meapd5525dMMy11Ohyq8pNwN3ATTQ38z6a5EhVPf3mmKr6IvDFdvyngT+sqpfHXubGqnpxqlsuTcBcS+d0OSLYCSxW1amqeh04DOx5i/G3AvdPY+OkGTLXUqtLI9gGPDc2vdTOO0+SdwO7gK+NzS7gkSTHkuxbrUiSfUkWkiycOXOmw2ZJEzHXUqtLI8gK82qVsZ8G/mnZ4fPHqupaYDfwuSSfWGnFqjpYVaOqGm3durXDZkkTMddSq0sjWAKuGJu+HDi9yti9LDt8rqrT7Z8vAA/QHJJLfTPXUqtLIzgK7EiyPclmmjfFkeWDkrwH+CTwN2PztiS5+M3nwKeAE9PYcGlC5lpqrXnWUFWdTXIn8DCwCThUVSeT7G+XH2iHfgZ4pKpeG1v9MuCBJG/W+mpVfXOaOyBthLmWzknVah+L9mc0GtXCgqdmazaSHKuq0bzrmmvN0iS59spiSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeA6NYIku5I8k2QxyV0rLL8hyatJjrePL3RdV+qLuZYaa96hLMkm4G7gJpr7vB5NcqSqnl429NtV9ZsbXFeaK3MtndPliGAnsFhVp6rqdeAwsKfj60+yrjRL5lpqdWkE24DnxqaX2nnL/UqSJ5I8lORD61yXJPuSLCRZOHPmTIfNkiZirqVWl0aQFeYtv9HxvwI/W1XXAH8JfGMd6zYzqw5W1aiqRlu3bu2wWdJEzLXU6tIIloArxqYvB06PD6iqH1TVf7XPHwTeleTSLutKPTHXUqtLIzgK7EiyPclmYC9wZHxAkp9Okvb5zvZ1X+qyrtQTcy211jxrqKrOJrkTeBjYBByqqpNJ9rfLDwC3AL+b5Czw38DeqipgxXVntC9SZ+ZaOidNri8so9GoFhYW+t4MvUMlOVZVo3nXNdeapUly7ZXFkjRwNgJJGjgbgSQNnI1AkgbORiBJA2cjkKSBsxFI0sDZCCRp4GwEkjRwNgJJGjgbgSQNnI1AkgbORiBJA2cjkKSBsxFI0sDZCCRp4Do1giS7kjyTZDHJXSss/2ySJ9vHY0muGVv2/SRPJTmexLty6IJhrqXGmreqTLIJuBu4ieam3UeTHKmqp8eGfQ/4ZFW9kmQ3cBC4bmz5jVX14hS3W5qIuZbO6XJEsBNYrKpTVfU6cBjYMz6gqh6rqlfayceBy6e7mdLUmWup1aURbAOeG5teauet5g7gobHpAh5JcizJvtVWSrIvyUKShTNnznTYLGki5lpqrfnREJAV5q14x/skN9K8YT4+NvtjVXU6yfuAbyX5t6p69LwXrDpIc+jNaDRa8fWlKTLXUqvLEcEScMXY9OXA6eWDknwYuBfYU1UvvTm/qk63f74APEBzSC71zVxLrS6N4CiwI8n2JJuBvcCR8QFJrgS+DvxOVX13bP6WJBe/+Rz4FHBiWhsvTcBcS601PxqqqrNJ7gQeBjYBh6rqZJL97fIDwBeAnwL+OgnA2aoaAZcBD7TzLgK+WlXfnMmeSOtgrqVzUnXhfWw5Go1qYcFTszUbSY61/6HPlbnWLE2Sa68slqSBsxFI0sDZCCRp4GwEkjRwNgJJGjgbgSQNnI1AkgbORiBJA2cjkKSBsxFI0sDZCCRp4GwEkjRwNgJJGjgbgSQNnI1AkgbORiBJA9epESTZleSZJItJ7lpheZJ8uV3+ZJJru64r9cVcS401G0GSTcDdwG7gauDWJFcvG7Yb2NE+9gH3rGNdae7MtXROlyOCncBiVZ2qqteBw8CeZWP2AF+pxuPAJUne33FdqQ/mWmqtefN6YBvw3Nj0EnBdhzHbOq4LQJJ9ND91AfxPkhMdtm3aLgVeHFDdPmv3uc8fYFi5hmH+Ow9tnz+w0RW7NIKsMG/5He9XG9Nl3WZm1UHgIECShT5uLj60un3W7nufGVCu+6ztPs+37kbX7dIIloArxqYvB053HLO5w7pSH8y11OryHcFRYEeS7Uk2A3uBI8vGHAFua8+yuB54taqe77iu1AdzLbXWPCKoqrNJ7gQeBjYBh6rqZJL97fIDwIPAzcAi8EPg9rdat8N2HdzIzkzB0Or2WbvXfR5Yrvus7T6/DeqmasWPNiVJA+GVxZI0cDYCSRq43hrBJJf3z6H2Z9uaTyZ5LMk186g7Nu6Xk7yR5JZp1O1aO8kNSY4nOZnkH+dRN8l7kvxtkifaurdPqe6hJC+sdt5+z/maSe2+ct2l9ti4qWa7r1x3qT2LbM8s11U19wfNF2zPAj9PcyreE8DVy8bcDDxEc8729cC/zLH2R4H3ts93T6N2l7pj4/6e5ovKW+a4z5cATwNXttPvm1PdPwb+on2+FXgZ2DyF2p8ArgVOrLK8z3xNvXZfue4z233lus9szyrXfR0RTHJ5/8xrV9VjVfVKO/k4zXniM6/b+j3ga8ALU6i5ntq/BXy9qv4DoKqmUb9L3QIuThLgJ2jeLGcnLVxVj7avtZre8jWj2n3lulPt1rSz3Veuu9aeerZnleu+GsFql+6vd8ysao+7g6bDzrxukm3AZ4ADU6i3rtrALwLvTfIPSY4luW1Odf8K+CDNBVlPAb9fVf83hdrT2LZZve4saveV6061Z5TtvnLdtXYf2d5QtrpcWTwLk1zeP4/azcDkRpo3zMfnVPdLwB9V1RvNDxFT06X2RcBHgF8Dfhz45ySPV9V3Z1z314HjwK8CvwB8K8m3q+oHE9Sd1rbN6nVnUbuvXHet/SWmn+2+ct21dh/Z3lC2+moEk1zeP4/aJPkwcC+wu6pemlPdEXC4faNcCtyc5GxVfWMOtZeAF6vqNeC1JI8C1wCTvGG61L0d+PNqPuBcTPI94CrgOxPUnda2zep1Z1G7r1x3rT2LbPeV6661+8j2xrI1jS9ONvCFx0XAKWA7575o+dCyMb/Bj37p8Z051r6S5mrSj85zn5eNv4/pfVncZZ8/CPxdO/bdwAngl+ZQ9x7gz9rnlwH/CVw6pf3+OVb/Uq3PfE29dl+57jPbfeW672zPItdTC8MGduZmmq78LPAn7bz9wP72eWhu/vEszedroznWvhd4heaw7jiwMI+6y8ZO5c2yntrA52nOsDgB/MGc/q5/Bnik/Tc+Afz2lOreDzwP/C/NT0l3XED5mkntvnLdZ7b7ynVf2Z5Vrv0VE5I0cF5ZLEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA3c/wNSo9bpO18IrQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 432x288 with 4 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "anim = surface.show(plot_energies=True, si=True)\n",
     "show_HTML(anim)"

--- a/docs/applications/gamma_surfaces.ipynb
+++ b/docs/applications/gamma_surfaces.ipynb
@@ -97,7 +97,7 @@
    "source": [
     "To generate some stacking fault images, we use `GammaSurface.generate_images`. We will then use `GammaSurface.show()` to construct a nice `matplotlib.animation.FuncAnimation` showing the surface. We will also disable the periodicity in z to create free surfaces, which can be done via setting `vacuum=True`.\n",
     "\n",
-    ":::{note}\n",
+    ":::{caution}\n",
     "The argument `vacuum` works differently depending on if you are using Method 1 (`cell_move=False`) or Method 2 (`cell_move=True`). For Method 1, `vacuum` toggles the periodicity in z on (`vacuum=False`) or off (`vacuum=True`), whereas for Method 2 is should be a float which gives the thickness of a vacuum layer to add in the center of the cell (between the periodic images of the gamma surfaces).\n",
     ":::"
    ]
@@ -188,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "images = surface.generate_images(n=16, cell_move=True, z_reps=4)\n",
+    "images = surface.generate_images(n=17, cell_move=True, z_reps=4)\n",
     "# Calc not attached, so can pass it here\n",
     "Es = surface.get_energy_densities(relax=True, calculator=calc) "
    ]
@@ -211,13 +211,6 @@
     "anim = surface.show(plot_energies=True, si=True)\n",
     "show_HTML(anim)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/applications/gamma_surfaces.ipynb
+++ b/docs/applications/gamma_surfaces.ipynb
@@ -10,7 +10,8 @@
     "from IPython.display import HTML\n",
     "def show_HTML(anim):\n",
     "    '''\n",
-    "    Convert matplotlib.animation.FuncAnimation (e.g. from GammaSurface.show()) to HTML viewable object.\n",
+    "    Convert matplotlib.animation.FuncAnimation \n",
+    "    (e.g. from GammaSurface.show()) to HTML viewable object.\n",
     "\n",
     "    anim: matplotlib.animation.FuncAnimation object\n",
     "        Animation to convert to HTML\n",
@@ -54,13 +55,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "from matscipy.gamma_surface import StackingFault, GammaSurface\n",
-    "from matscipy.calculators.manybody.explicit_forms.tersoff_brenner import TersoffBrenner, \\\n",
-    "                                                                         Kioseoglou_PSSb_245_1118_AlN\n",
+    "from matscipy.calculators.manybody.explicit_forms.tersoff_brenner import \\\n",
+    "                            TersoffBrenner, Kioseoglou_PSSb_245_1118_AlN\n",
+    "\n",
     "from matscipy.calculators.manybody import Manybody\n",
     "from matscipy.dislocation import get_elastic_constants\n",
     "\n",
@@ -70,8 +72,11 @@
     "\n",
     "# Initialise a GammaSurface instance\n",
     "# We could use (100) as the surface direction, but (001) should be equivalent\n",
-    "surface = GammaSurface(alat, surface_direction=(0, 0, 1), crystalstructure=\"fcc\", symbol=\"Al\")\n",
-    "surface.calc = calc # Attach the calculator to the surface, so we don't need to keep feeding it in later"
+    "surface = GammaSurface(alat, surface_direction=(0, 0, 1), \n",
+    "                       crystalstructure=\"fcc\", symbol=\"Al\")\n",
+    "\n",
+    "# Attach the calculator to the surface, so we don't need to keep feeding it in later\n",
+    "surface.calc = calc "
    ]
   },
   {
@@ -170,7 +175,8 @@
    "outputs": [],
    "source": [
     "images = surface.generate_images(n=16, cell_move=True, z_reps=4)\n",
-    "Es = surface.get_energy_densities(relax=True, calculator=calc) # Calc not attached, so can pass it here"
+    "# Calc not attached, so can pass it here\n",
+    "Es = surface.get_energy_densities(relax=True, calculator=calc) "
    ]
   },
   {
@@ -183,7 +189,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "anim = surface.show(plot_energies=True, si=True)\n",

--- a/docs/applications/gamma_surfaces.ipynb
+++ b/docs/applications/gamma_surfaces.ipynb
@@ -45,12 +45,12 @@
     "The first and most intuitive method involves splitting a supercell of this rotated structure into an upper and lower slab, and translating the top slab relative to the bottom. In the fully periodic case, this creates two stacking faults in the cell, at both the upper and lower boundaries of the top slab. We could instead choose to leave free surfaces above the top slab and below the bottom slab by removing the periodicity in the direction of the surface normal, which leaves us with a single gamma surface between the slabs.\n",
     "\n",
     "## Method 2 - \"Cell Move\" Method\n",
-    "The second method method is more efficient as it reduces the number of atoms required, but is less intuitive to understand. Instead of moving atoms, we instead modify the cell vectors without moving the atoms. In doing this, we translate the periodic image of the bottom of the structure relative to the top of the structure, and vice versa, thus skipping the need to have two slabs. This method always produces a structure containing a single gamma surface, which is always at the cell boundaries. In order to model the free-surface approach, we can add vacuum to the center of the cell, which creates a similar two slab setup as method 1, but this time in a periodic cell.\n",
+    "The second method method is more efficient as it reduces the number of atoms required, but is less intuitive to understand. Instead of moving atoms, we modify the cell vectors without moving the atoms. In doing this, we translate the periodic image of the bottom of the structure relative to the top of the structure, and vice versa, thus skipping the need to have two slabs. This method always produces a structure containing a single gamma surface, which is always at the cell boundaries. In order to model the free-surface approach, we can add vacuum to the center of the cell, which creates a similar two slab setup as method 1, but this time in a periodic cell.\n",
     "\n",
     "NOTE: `GammaSurface` and `StackingFault` are extremely closely related as classes. To avoid these docs from becoming an API reference, lots of the additional features are spread across all examples. Though basic usage of the code can be achieved purely by copying the first example, the recommendation is to have a quick glance at all examples in order to see how the code may be parametised to suit your needs.\n",
     "\n",
     "## Gamma Surface Example using Method 1\n",
-    "We will start with a very basic gamma surface, using the example of the (100) surface in FCC Aluminium, using the first method described above. We will use a model by (Kioseoglou et al)[] in order to perform some relaxations, and see what the surface looks like."
+    "We will start with a very basic gamma surface, using the example of the (100) surface in FCC Aluminium, using the first method described above. We will use a model by [Kioseoglou et al](https://doi.org/10.1002/pssb.200844122) in order to perform some relaxations, and see what the surface looks like."
    ]
   },
   {
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then use `GammaSurface.relax_images()` and `GammaSurface.get_energy_densities()` to perform some relaxations and then get the energy density profile using the calculator we attached. If no calculator was attached, we could instead pass one in using the `calculator=calc` arg.\n",
+    "We can then use `GammaSurface.relax_images()` and `GammaSurface.get_energy_densities()` to perform some relaxations and then get the energy density profile using the calculator we attached. If no calculator was attached, we could instead pass one in using the `calculator=calc` argument.\n",
     "\n",
     "By default, the code will apply the required constraints that all atoms only relax in the z direction, and to allow the cell to relax in z as well (the cell[2, 2] component). As we have a vacuum layer, the cell relaxation does not make sense, so we can disable this using `cell_relax=False`"
    ]
@@ -161,11 +161,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will generate our stacking fault images using Method 2 described above, which is the fully periodic scheme using cell moves. This is activated using the `cell_move=True` arg of `generate_images`.\n",
+    "We will generate our stacking fault images using Method 2 described above, which is the fully periodic scheme using cell moves. This is activated using the `cell_move=True` argument of `generate_images`.\n",
     "\n",
     "In the gamma surface example, there was very little distance between the stacking fault and the free surface. Normally, we aim to approximate gamma surfaces surrounded by lots of bulk in some way, so this approach leaves lots of room to improvement. We can extend the cell in the z direction using `z_reps`, which will move the periodic images of the surface apart. The images are purposefully kept very small in these examples for both speed and ease of visualisation, but in practice this should be set based on a convergence criterion.\n",
     "\n",
-    "Instead of having to call both `relax_images()` and `get_energy_densities()` ourselves, we can use the `relax=True` arg of `get_energy_densities()` to run the relaxation and get the energies in a single line."
+    "Instead of having to call both `relax_images()` and `get_energy_densities()` ourselves, we can use the `relax=True` argument of `get_energy_densities()` to run the relaxation and get the energies in a single line."
    ]
   },
   {
@@ -183,20 +183,57 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, both the `plot_energy_densities()` and `show(plot_energies=True)` methods of the `GammaSurface` and `StackingFaults` use energy density units of eV/A^2, but often literature will give numbers in the SI units J/m^2. To convert to SI in the plots, we can use the `si=True` arg."
+    "By default, both the `plot_energy_densities()` and `show(plot_energies=True)` methods of the `GammaSurface` and `StackingFaults` use energy density units of eV/A$^2$, but often literature will give numbers in the SI units J/m$^2$. To convert to SI in the plots, we can use the `si=True` argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "RuntimeError",
+     "evalue": "Cannot plot energy densities before get_energy_densities is called!",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "File \u001b[0;32m~/anaconda3/envs/quippy-ase/lib/python3.9/site-packages/matscipy/gamma_surface.py:531\u001b[0m, in \u001b[0;36mGammaSurface.show\u001b[0;34m(self, CNA_color, plot_energies, si, **kwargs)\u001b[0m\n\u001b[1;32m    529\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[1;32m    530\u001b[0m     \u001b[39m# Assume that calculator is attached so we can get energy densities\u001b[39;00m\n\u001b[0;32m--> 531\u001b[0m     Es \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mget_energy_densities()\n\u001b[1;32m    532\u001b[0m \u001b[39mexcept\u001b[39;00m:\n",
+      "File \u001b[0;32m~/anaconda3/envs/quippy-ase/lib/python3.9/site-packages/matscipy/gamma_surface.py:376\u001b[0m, in \u001b[0;36mGammaSurface.get_energy_densities\u001b[0;34m(self, calculator, relax, **relax_kwargs)\u001b[0m\n\u001b[1;32m    374\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mRuntimeError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mNo calculator supplied for energy evaluation\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 376\u001b[0m cell \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mimages[\u001b[39m0\u001b[39;49m]\u001b[39m.\u001b[39mcell[:, :]\n\u001b[1;32m    377\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39msurface_area \u001b[39m=\u001b[39m np\u001b[39m.\u001b[39mlinalg\u001b[39m.\u001b[39mnorm(np\u001b[39m.\u001b[39mcross(cell[\u001b[39m0\u001b[39m, :], cell[\u001b[39m1\u001b[39m, :]))\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[1;32m/home/petr/gits/matscipy/docs/applications/gamma_surfaces.ipynb Cell 15\u001b[0m line \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/petr/gits/matscipy/docs/applications/gamma_surfaces.ipynb#X42sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m anim \u001b[39m=\u001b[39m surface\u001b[39m.\u001b[39;49mshow(plot_energies\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m, si\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m)\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/petr/gits/matscipy/docs/applications/gamma_surfaces.ipynb#X42sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m show_HTML(anim)\n",
+      "File \u001b[0;32m~/anaconda3/envs/quippy-ase/lib/python3.9/site-packages/matscipy/gamma_surface.py:533\u001b[0m, in \u001b[0;36mGammaSurface.show\u001b[0;34m(self, CNA_color, plot_energies, si, **kwargs)\u001b[0m\n\u001b[1;32m    531\u001b[0m             Es \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mget_energy_densities()\n\u001b[1;32m    532\u001b[0m         \u001b[39mexcept\u001b[39;00m:\n\u001b[0;32m--> 533\u001b[0m             \u001b[39mraise\u001b[39;00m \u001b[39mRuntimeError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mCannot plot energy densities before get_energy_densities is called!\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    535\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mplot_energy_densities(ax\u001b[39m=\u001b[39menergy_ax, si\u001b[39m=\u001b[39msi)\n\u001b[1;32m    536\u001b[0m \u001b[39melse\u001b[39;00m:\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: Cannot plot energy densities before get_energy_densities is called!"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD8CAYAAAB6paOMAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAWpUlEQVR4nO3df6xf9V3H8efLsiaukjGlw1lAq6ljzIyEfS24LRtomC26NEv4ozglISRNzTDqH4tEk+mfmv2zTJGmIQ3ZH6P/bMyawGDRKIuI660p0BJZLt2Ua0koP8IiM2Lx7R/nkH53ey/33Pv9cQrn+Ui+6fec8znf9znt69v3Pd/vOfekqpAkDdeP9b0BkqR+2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGbs1GkORQkheSnFhleZJ8OclikieTXDu2bFeSZ9pld01zw6VJmW2p0eWI4D5g11ss3w3saB/7gHsAkmwC7m6XXw3cmuTqSTZWmrL7MNvS2o2gqh4FXn6LIXuAr1TjceCSJO8HdgKLVXWqql4HDrdjpQuC2ZYaF03hNbYBz41NL7XzVpp/3WovkmQfzU9dbNmy5SNXXXXVFDZNOt+xY8derKqtHYZOnG1zrXlZR67PM41GkBXm1VvMX1FVHQQOAoxGo1pYWJjCpknnS/LvXYeuMG9d2TbXmpd15Po802gES8AVY9OXA6eBzavMl94uzLYGYRqnjx4BbmvPsLgeeLWqngeOAjuSbE+yGdjbjpXeLsy2BmHNI4Ik9wM3AJcmWQL+FHgXQFUdAB4EbgYWgR8Ct7fLzia5E3gY2AQcqqqTM9gHaUPMttRYsxFU1a1rLC/gc6sse5DmzSRdcMy21PDKYkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHCdGkGSXUmeSbKY5K4Vln8+yfH2cSLJG0l+sl32/SRPtcu8c7cuGOZaanS5VeUm4G7gJpqbeR9NcqSqnn5zTFV9EfhiO/7TwB9W1ctjL3NjVb041S2XJmCupXO6HBHsBBar6lRVvQ4cBva8xfhbgfunsXHSDJlrqdWlEWwDnhubXmrnnSfJu4FdwNfGZhfwSJJjSfatViTJviQLSRbOnDnTYbOkiZhrqdWlEWSFebXK2E8D/7Ts8PljVXUtsBv4XJJPrLRiVR2sqlFVjbZu3dphs6SJmGup1aURLAFXjE1fDpxeZexelh0+V9Xp9s8XgAdoDsmlvplrqdWlERwFdiTZnmQzzZviyPJBSd4DfBL4m7F5W5Jc/OZz4FPAiWlsuDQhcy211jxrqKrOJrkTeBjYBByqqpNJ9rfLD7RDPwM8UlWvja1+GfBAkjdrfbWqvjnNHZA2wlxL56RqtY9F+zMajWphwVOzNRtJjlXVaN51zbVmaZJce2WxJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkauE6NIMmuJM8kWUxy1wrLb0jyapLj7eMLXdeV+mKupcaat6pMsgm4G7iJ5obfR5Mcqaqnlw39dlX95gbXlebKXEvndDki2AksVtWpqnodOAzs6fj6k6wrzZK5llpdGsE24Lmx6aV23nK/kuSJJA8l+dA61yXJviQLSRbOnDnTYbOkiZhrqdWlEWSFecvveP+vwM9W1TXAXwLfWMe6zcyqg1U1qqrR1q1bO2yWNBFzLbW6NIIl4Iqx6cuB0+MDquoHVfVf7fMHgXclubTLulJPzLXU6tIIjgI7kmxPshnYCxwZH5Dkp5Okfb6zfd2Xuqwr9cRcS601zxqqqrNJ7gQeBjYBh6rqZJL97fIDwC3A7yY5C/w3sLeqClhx3Rnti9SZuZbOSZPrC8toNKqFhYW+N0PvUEmOVdVo3nXNtWZpklx7ZbEkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cJ0aQZJdSZ5JspjkrhWWfzbJk+3jsSTXjC37fpKnkhxP4i9j1wXDXEuNNe9QlmQTcDdwE829Wo8mOVJVT48N+x7wyap6Jclu4CBw3djyG6vqxSlutzQRcy2d0+WIYCewWFWnqup14DCwZ3xAVT1WVa+0k4/T3MxbupCZa6nVpRFsA54bm15q563mDuChsekCHklyLMm+1VZKsi/JQpKFM2fOdNgsaSLmWmqt+dEQkBXmrXij4yQ30rxhPj42+2NVdTrJ+4BvJfm3qnr0vBesOkhz6M1oNLrwbqSsdxpzLbW6HBEsAVeMTV8OnF4+KMmHgXuBPVX10pvzq+p0++cLwAM0h+RS38y11OrSCI4CO5JsT7IZ2AscGR+Q5Erg68DvVNV3x+ZvSXLxm8+BTwEnprXx0gTMtdRa86Ohqjqb5E7gYWATcKiqTibZ3y4/AHwB+Cngr5MAnK2qEXAZ8EA77yLgq1X1zZnsibQO5lo6J1UX3seWo9GoFhY8NVuzkeRY+x/6XJlrzdIkufbKYkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA2cjUCSBs5GIEkDZyOQpIGzEUjSwNkIJGngbASSNHCdGkGSXUmeSbKY5K4VlifJl9vlTya5tuu6Ul/MtdRYsxEk2QTcDewGrgZuTXL1smG7gR3tYx9wzzrWlebOXEvndDki2AksVtWpqnodOAzsWTZmD/CVajwOXJLk/R3XlfpgrqXWmjevB7YBz41NLwHXdRizreO6ACTZR/NTF8D/JDnRYdum7VLgxQHV7bN2n/v8AYaVaxjmv/PQ9vkDG12xSyPICvOW3/F+tTFd1m1mVh0EDgIkWejj5uJDq9tn7b73mQHlus/a7vN862503S6NYAm4Ymz6cuB0xzGbO6wr9cFcS60u3xEcBXYk2Z5kM7AXOLJszBHgtvYsi+uBV6vq+Y7rSn0w11JrzSOCqjqb5E7gYWATcKiqTibZ3y4/ADwI3AwsAj8Ebn+rdTts18GN7MwUDK1un7V73eeB5brP2u7z26Buqlb8aFOSNBBeWSxJA2cjkKSB660RTHJ5/xxqf7at+WSSx5JcM4+6Y+N+OckbSW6ZRt2utZPckOR4kpNJ/nEedZO8J8nfJnmirXv7lOoeSvLCauft95yvmdTuK9ddao+Nm2q2+8p1l9qzyPbMcl1Vc3/QfMH2LPDzNKfiPQFcvWzMzcBDNOdsXw/8yxxrfxR4b/t89zRqd6k7Nu7vab6ovGWO+3wJ8DRwZTv9vjnV/WPgL9rnW4GXgc1TqP0J4FrgxCrL+8zX1Gv3les+s91XrvvM9qxy3dcRwSSX98+8dlU9VlWvtJOP05wnPvO6rd8Dvga8MIWa66n9W8DXq+o/AKpqGvW71C3g4iQBfoLmzXJ20sJV9Wj7WqvpLV8zqt1XrjvVbk07233lumvtqWd7VrnuqxGsdun+esfMqva4O2g67MzrJtkGfAY4MIV666oN/CLw3iT/kORYktvmVPevgA/SXJD1FPD7VfV/U6g9jW2b1evOonZfue5Ue0bZ7ivXXWv3ke0NZavLlcWzMMnl/fOo3QxMbqR5w3x8TnW/BPxRVb3R/BAxNV1qXwR8BPg14MeBf07yeFV9d8Z1fx04Dvwq8AvAt5J8u6p+MEHdaW3brF53FrX7ynXX2l9i+tnuK9dda/eR7Q1lq69GMMnl/fOoTZIPA/cCu6vqpTnVHQGH2zfKpcDNSc5W1TfmUHsJeLGqXgNeS/IocA0wyRumS93bgT+v5gPOxSTfA64CvjNB3Wlt26xedxa1+8p119qzyHZfue5au49sbyxb0/jiZANfeFwEnAK2c+6Llg8tG/Mb/OiXHt+ZY+0raa4m/eg893nZ+PuY3pfFXfb5g8DftWPfDZwAfmkOde8B/qx9fhnwn8ClU9rvn2P1L9X6zNfUa/eV6z6z3Veu+872LHI9tTBsYGdupunKzwJ/0s7bD+xvn4fm5h/P0ny+Nppj7XuBV2gO644DC/Oou2zsVN4s66kNfJ7mDIsTwB/M6e/6Z4BH2n/jE8BvT6nu/cDzwP/S/JR0xwWUr5nU7ivXfWa7r1z3le1Z5dpfMSFJA9flVpUbvoCh60UmUh/MttTocvrofcCut1jufV31dnUfZltauxHUxi9g8L6uuqCZbakxjdNHJ76vK/zovV23bNnykauuumoKmyad79ixYy9W1dYOQ6d6z2JzrVlaR67PM41GMPF9XeFH7+06Go1qYWHDt9+U3lKSf+86dIV568q2uda8rCPX55lGI/C+rnqnMtsahGn8riHv66p3KrOtQVjziCDJ/cANwKVJloA/Bd4FM7uvqzQXZltqdLl5/a1rLC/gc6sse5DmzSRdcMy21PBWlZI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeA6NYIku5I8k2QxyV0rLP98kuPt40SSN5L8ZLvs+0meapd5525dMMy11Ohyq8pNwN3ATTQ38z6a5EhVPf3mmKr6IvDFdvyngT+sqpfHXubGqnpxqlsuTcBcS+d0OSLYCSxW1amqeh04DOx5i/G3AvdPY+OkGTLXUqtLI9gGPDc2vdTOO0+SdwO7gK+NzS7gkSTHkuxbrUiSfUkWkiycOXOmw2ZJEzHXUqtLI8gK82qVsZ8G/mnZ4fPHqupaYDfwuSSfWGnFqjpYVaOqGm3durXDZkkTMddSq0sjWAKuGJu+HDi9yti9LDt8rqrT7Z8vAA/QHJJLfTPXUqtLIzgK7EiyPclmmjfFkeWDkrwH+CTwN2PztiS5+M3nwKeAE9PYcGlC5lpqrXnWUFWdTXIn8DCwCThUVSeT7G+XH2iHfgZ4pKpeG1v9MuCBJG/W+mpVfXOaOyBthLmWzknVah+L9mc0GtXCgqdmazaSHKuq0bzrmmvN0iS59spiSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeBsBJI0cDYCSRo4G4EkDZyNQJIGzkYgSQNnI5CkgbMRSNLA2QgkaeA6NYIku5I8k2QxyV0rLL8hyatJjrePL3RdV+qLuZYaa96hLMkm4G7gJpr7vB5NcqSqnl429NtV9ZsbXFeaK3MtndPliGAnsFhVp6rqdeAwsKfj60+yrjRL5lpqdWkE24DnxqaX2nnL/UqSJ5I8lORD61yXJPuSLCRZOHPmTIfNkiZirqVWl0aQFeYtv9HxvwI/W1XXAH8JfGMd6zYzqw5W1aiqRlu3bu2wWdJEzLXU6tIIloArxqYvB06PD6iqH1TVf7XPHwTeleTSLutKPTHXUqtLIzgK7EiyPclmYC9wZHxAkp9Okvb5zvZ1X+qyrtQTcy211jxrqKrOJrkTeBjYBByqqpNJ9rfLDwC3AL+b5Czw38DeqipgxXVntC9SZ+ZaOidNri8so9GoFhYW+t4MvUMlOVZVo3nXNdeapUly7ZXFkjRwNgJJGjgbgSQNnI1AkgbORiBJA2cjkKSBsxFI0sDZCCRp4GwEkjRwNgJJGjgbgSQNnI1AkgbORiBJA2cjkKSBsxFI0sDZCCRp4Do1giS7kjyTZDHJXSss/2ySJ9vHY0muGVv2/SRPJTmexLty6IJhrqXGmreqTLIJuBu4ieam3UeTHKmqp8eGfQ/4ZFW9kmQ3cBC4bmz5jVX14hS3W5qIuZbO6XJEsBNYrKpTVfU6cBjYMz6gqh6rqlfayceBy6e7mdLUmWup1aURbAOeG5teauet5g7gobHpAh5JcizJvtVWSrIvyUKShTNnznTYLGki5lpqrfnREJAV5q14x/skN9K8YT4+NvtjVXU6yfuAbyX5t6p69LwXrDpIc+jNaDRa8fWlKTLXUqvLEcEScMXY9OXA6eWDknwYuBfYU1UvvTm/qk63f74APEBzSC71zVxLrS6N4CiwI8n2JJuBvcCR8QFJrgS+DvxOVX13bP6WJBe/+Rz4FHBiWhsvTcBcS601PxqqqrNJ7gQeBjYBh6rqZJL97fIDwBeAnwL+OgnA2aoaAZcBD7TzLgK+WlXfnMmeSOtgrqVzUnXhfWw5Go1qYcFTszUbSY61/6HPlbnWLE2Sa68slqSBsxFI0sDZCCRp4GwEkjRwNgJJGjgbgSQNnI1AkgbORiBJA2cjkKSBsxFI0sDZCCRp4GwEkjRwNgJJGjgbgSQNnI1AkgbORiBJA9epESTZleSZJItJ7lpheZJ8uV3+ZJJru64r9cVcS401G0GSTcDdwG7gauDWJFcvG7Yb2NE+9gH3rGNdae7MtXROlyOCncBiVZ2qqteBw8CeZWP2AF+pxuPAJUne33FdqQ/mWmqtefN6YBvw3Nj0EnBdhzHbOq4LQJJ9ND91AfxPkhMdtm3aLgVeHFDdPmv3uc8fYFi5hmH+Ow9tnz+w0RW7NIKsMG/5He9XG9Nl3WZm1UHgIECShT5uLj60un3W7nufGVCu+6ztPs+37kbX7dIIloArxqYvB053HLO5w7pSH8y11OryHcFRYEeS7Uk2A3uBI8vGHAFua8+yuB54taqe77iu1AdzLbXWPCKoqrNJ7gQeBjYBh6rqZJL97fIDwIPAzcAi8EPg9rdat8N2HdzIzkzB0Or2WbvXfR5Yrvus7T6/DeqmasWPNiVJA+GVxZI0cDYCSRq43hrBJJf3z6H2Z9uaTyZ5LMk186g7Nu6Xk7yR5JZp1O1aO8kNSY4nOZnkH+dRN8l7kvxtkifaurdPqe6hJC+sdt5+z/maSe2+ct2l9ti4qWa7r1x3qT2LbM8s11U19wfNF2zPAj9PcyreE8DVy8bcDDxEc8729cC/zLH2R4H3ts93T6N2l7pj4/6e5ovKW+a4z5cATwNXttPvm1PdPwb+on2+FXgZ2DyF2p8ArgVOrLK8z3xNvXZfue4z233lus9szyrXfR0RTHJ5/8xrV9VjVfVKO/k4zXniM6/b+j3ga8ALU6i5ntq/BXy9qv4DoKqmUb9L3QIuThLgJ2jeLGcnLVxVj7avtZre8jWj2n3lulPt1rSz3Veuu9aeerZnleu+GsFql+6vd8ysao+7g6bDzrxukm3AZ4ADU6i3rtrALwLvTfIPSY4luW1Odf8K+CDNBVlPAb9fVf83hdrT2LZZve4saveV6061Z5TtvnLdtXYf2d5QtrpcWTwLk1zeP4/azcDkRpo3zMfnVPdLwB9V1RvNDxFT06X2RcBHgF8Dfhz45ySPV9V3Z1z314HjwK8CvwB8K8m3q+oHE9Sd1rbN6nVnUbuvXHet/SWmn+2+ct21dh/Z3lC2+moEk1zeP4/aJPkwcC+wu6pemlPdEXC4faNcCtyc5GxVfWMOtZeAF6vqNeC1JI8C1wCTvGG61L0d+PNqPuBcTPI94CrgOxPUnda2zep1Z1G7r1x3rT2LbPeV6661+8j2xrI1jS9ONvCFx0XAKWA7575o+dCyMb/Bj37p8Z051r6S5mrSj85zn5eNv4/pfVncZZ8/CPxdO/bdwAngl+ZQ9x7gz9rnlwH/CVw6pf3+OVb/Uq3PfE29dl+57jPbfeW672zPItdTC8MGduZmmq78LPAn7bz9wP72eWhu/vEszedroznWvhd4heaw7jiwMI+6y8ZO5c2yntrA52nOsDgB/MGc/q5/Bnik/Tc+Afz2lOreDzwP/C/NT0l3XED5mkntvnLdZ7b7ynVf2Z5Vrv0VE5I0cF5ZLEkDZyOQpIGzEUjSwNkIJGngbASSNHA2AkkaOBuBJA3c/wNSo9bpO18IrQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 432x288 with 4 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "anim = surface.show(plot_energies=True, si=True)\n",
+    "show_HTML(anim)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
-   "source": [
-    "anim = surface.show(plot_energies=True, si=True)\n",
-    "show_HTML(anim)"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/applications/gamma_surfaces.ipynb
+++ b/docs/applications/gamma_surfaces.ipynb
@@ -192,14 +192,25 @@
   }
  ],
  "metadata": {
+  "execution": {
+   "timeout": 180
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.9.18"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/applications/plasticity.rst
+++ b/docs/applications/plasticity.rst
@@ -5,9 +5,8 @@ For large loads, solids can respond with irreversible deformation. One form of i
 
 Creating an atomistic system containing a dislocation requires a rather deep knowledge of crystallographic system, elasticity theory as well as hands on experience with atomistic simulations. Thus, it can be challenging for people not familiar to the field. Within this module we attempt to create a flexible, friendly and pythonic tool to enable atomistic simulations of dislocations with ease. The base of the model is :class:`matscipy.dislocation.CubicCrystalDislocation` class that contains all the necessary information to create an atomistic dislocation. To start experimenting, a user only has to choose the dislocation of interest and provide a lattice parameter and elastic constants.
 
-Some dislocation systems feature additional complexity, as they can dissociate into two partial dislocations connected by a stacking fault. These kinds of dislocations subclass `matscipy.dislocation.CubicCrystalDissociatedDislocation`, and follow a near-identical interface.
+Some dislocation systems feature additional complexity, as they can dissociate into two partial dislocations connected by a stacking fault. These kinds of dislocations are implemented within the subclass :class:`matscipy.dislocation.CubicCrystalDissociatedDislocation` and follow a near-identical interface. :mod:`matscipy.gamma_surface` implements classes which assist in the modeling of stacking faults, as well as more general gamma surfaces. The classes can be initialised based on a dislocation system, or by known axes. 
 
-:mod:`matscipy.gamma_surface` implements classes which assist in the modeling of these stacking faults, as well as more general gamma surfaces. The classes can be initialised based on a dislocation system, or by known axes. 
 Installation and tests
 ----------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,4 +287,6 @@ autodoc_default_options = {
 }
 
 myst_enable_extensions = [
-    "dollarmath"]
+    "dollarmath",
+    "colon_fence",
+    ]

--- a/matscipy/gamma_surface.py
+++ b/matscipy/gamma_surface.py
@@ -558,8 +558,9 @@ class GammaSurface():
 
 
         animation = FuncAnimation(fig, drawimage, frames=enumerate(images),
-                                init_func=lambda: None,
-                                interval=200)
+                                  save_count=len(images),
+                                  init_func=lambda: None,
+                                  interval=200)
         return animation
 
 
@@ -712,6 +713,7 @@ class StackingFault(GammaSurface):
 
 
         animation = FuncAnimation(fig, drawimage, frames=enumerate(images),
-                                init_func=lambda: None,
-                                interval=200)
+                                  save_count=len(images),
+                                  init_func=lambda: None,
+                                  interval=200)
         return animation

--- a/matscipy/gamma_surface.py
+++ b/matscipy/gamma_surface.py
@@ -6,29 +6,35 @@ import warnings
 from ase.constraints import UnitCellFilter
 from matscipy.utils import validate_cubic_cell, complete_basis
 import inspect
-from matscipy.dislocation import CubicCrystalDislocation, CubicCrystalDissociatedDislocation
+from matscipy.dislocation import CubicCrystalDislocation, \
+                                 CubicCrystalDissociatedDislocation
 from ase.units import _e
+
 
 class GammaSurface():
     '''
     A class for generating gamma surface/generalised stacking fault images & plots
     '''
-    def __init__(self, a, surface_direction, glide_direction=None, crystalstructure=None, symbol="C"):
+    def __init__(self, a, surface_direction, glide_direction=None,
+                 crystalstructure=None, symbol="C"):
         '''
         Initialise by cutting and rotating the input structure.
 
         Parameters
         ----------
         a: float or ase.Atoms
-            Lattice Constant or Starting structure to generate gamma surface from
-            (Operates similarly to CubicCrystalDislocation)
+            Lattice Constant or Starting structure to generate gamma surface
+            from (Operates similarly to CubicCrystalDislocation)
             If lattice constant is provided, crystalstructure must also be set
-        surface_direction: np.array of int or subclass of matscipy.dislocation.CubicCrystalDissociatedDislocation
+        surface_direction: np.array of int or subclass of
+            matscipy.dislocation.CubicCrystalDissociatedDislocation
             Vector direction of gamma surface, in miller index notation
             EG: np.array([0, 0, 1]), np.array([-1, 1, 0]), np.array([1, 1, 1])
-            A subclass of matscipy.dislocation.CubicCrystalDissociatedDislocation (EG: DiamondGlideScrew or FCCEdge110Dislocation)
+            A subclass of matscipy.dislocation.CubicCrystalDissociatedDislocation 
+            (EG: DiamondGlideScrew or FCCEdge110Dislocation)
         glide_direction: np.array of int or None
-            Basis vector (in miller indices) to form the glide direction of the stacking fault, which is oriented along the y axis of generated images
+            Basis vector (in miller indices) to form the glide direction of 
+            the stacking fault, which is oriented along the y axis of generated images
             Should be orthogonal to surface_direction
             If None, a suitable glide_direction will be found automatically
         crystalstructure: str
@@ -117,8 +123,10 @@ class GammaSurface():
                 "z": np.array(z)
                 }
             ax = np.array([x, y, z])
-        
-        alat, self.cut_at = validate_cubic_cell(a, axes=ax, crystalstructure=crystalstructure, symbol=symbol)
+
+        alat, self.cut_at = validate_cubic_cell(a, axes=ax, 
+                                                crystalstructure=crystalstructure,
+                                                symbol=symbol)
         self.offset *= alat
 
     def _vec_to_miller(self, vec, latex=True):
@@ -129,7 +137,7 @@ class GammaSurface():
             array to convert to string miller notation
             e.g. (100) or (11-2)
         latex: bool
-            Use LaTeX expressions to contstruct representation
+            Use LaTeX expressions to construct representation
         '''
         int_vec = vec.astype(int)
         l = []
@@ -140,25 +148,26 @@ class GammaSurface():
                 l.extend(str(item))
         return "(" + "".join(l) + ")"
 
-    def _gen_cellmove_images(self, base_struct, nx, ny, x_points, y_points, vacuum=0.0):
+    def _gen_cellmove_images(self, base_struct, 
+                             nx, ny, x_points, y_points, vacuum=0.0):
         # Add vacuum
         half_dist = base_struct.cell[2, 2] / 2
 
         atom_mask = base_struct.get_positions()[:, 2] > half_dist
-        
+
         cell = base_struct.cell[:, :].copy()
         cell[2, 2] += vacuum
         pos = base_struct.get_positions()
         pos[atom_mask, 2] += vacuum
         base_struct.set_positions(pos)
-        
+
         # Gen images
         images = []
         for i in range(nx):
             for j in range(ny):
                 offset = x_points[i] + y_points[j]
                 self.offsets.append(offset)
-            
+
                 new_cell = cell.copy()
                 new_cell[2, :] += offset
 
@@ -168,7 +177,7 @@ class GammaSurface():
 
                 images.append(ats)
         return images
-    
+
     def _gen_atommove_images(self, base_struct, nx, ny, x_points, y_points, vacuum):
         slab = stack(base_struct.copy(), base_struct.copy())
         z_cut = slab.cell[2, 2]/2
@@ -178,7 +187,7 @@ class GammaSurface():
 
         if vacuum:
             slab.set_pbc([True, True, False])
-        
+
         images = []
         for i in range(nx):
             for j in range(ny):
@@ -192,8 +201,7 @@ class GammaSurface():
                 images.append(ats)
         return images
 
-
-    def generate_images(self, nx, ny, z_reps=1, z_offset=0.0, cell_strain=0.0, vacuum=0.0, 
+    def generate_images(self, nx, ny, z_reps=1, z_offset=0.0, cell_strain=0.0, vacuum=0.0,
                         path_xlims=[0, 1], path_ylims=None, cell_move=True):
         '''
         Generate gamma surface images on an (nx, ny) grid
@@ -205,25 +213,31 @@ class GammaSurface():
         ny: int
             Number of points in the y direction
         z_reps: int
-            Number of supercell copies in z (increases separation between periodic surfaces)
+            Number of supercell copies in z
+            (increases separation between periodic surfaces)
         z_offset: float
             Offset in the z direction (in A) to apply to all atoms
-            Used to select different stacking fault planes sharing the same normal direction
+            Used to select different stacking fault planes
+            sharing the same normal direction
             (e.g. glide and shuffle planes in Diamond)
         cell_strain: float
-            Fractional strain to apply in z direction to cell only (0.1 = +10% strain; atoms aren't moved)
+            Fractional strain to apply in z direction to cell
+            only (0.1 = +10% strain; atoms aren't moved)
             Helpful for issues when atoms are extremely close in unrelaxed images.
         vacuum: float
-            Additional vacuum layer (in A) to add between periodic images of the gamma surface
+            Additional vacuum layer (in A) to add between periodic
+            images of the gamma surface
         vacuum_offset: float
-            Offset (in A) applied to the position of the vacuum layer in the cell
+            Offset (in A) applied to the position of
+            the vacuum layer in the cell
             The position of the vacuum layer is given by:
             vac_pos = self.cut_at.cell[2, 2] * (1 + cell_strain) / 2 + vacuum_offset
         path_xlims: list or array of floats
             Limits (in fractional coordinates) of the stacking fault path in the x direction
         path_ylims: list or array of floats
             Limits (in fractional coordinates) of the stacking fault path in the x direction
-            If not supplied, will be set to either [0, 1], or will be set based on the glide distance of the supplied dislocation
+            If not supplied, will be set to either [0, 1],
+            or will be set based on the glide distance of the supplied dislocation
         cell_move: bool
             Toggles using the cell move method (True) or atom move method (False)
 
@@ -237,7 +251,7 @@ class GammaSurface():
             y_lims = self.ylims
         else:
             y_lims = path_ylims
-        
+
         x_lims = path_xlims
 
         self.nx = nx
@@ -258,7 +272,7 @@ class GammaSurface():
         min_z = np.min(pos[:, 2])
         pos[:, 2] -= min_z
         base_struct.set_positions(pos)
-        
+
         # Apply cell strain
         new_cell = base_struct.cell[:, :].copy()
         new_cell[2, 2] += cell_strain
@@ -271,7 +285,7 @@ class GammaSurface():
 
         self.surface_area = np.linalg.norm(np.cross(cell[0, :], cell[1, :]))
         self.surface_separation = np.abs(cell[2, 2])
-                
+
         dx = self.x_disp / nx
         dy = self.y_disp / ny
 
@@ -289,14 +303,16 @@ class GammaSurface():
 
         if cell_move is True:
             # Generate images via cell moves
-            self.images = self._gen_cellmove_images(base_struct, nx, ny, x_points, y_points, vacuum)
+            self.images = self._gen_cellmove_images(base_struct, nx, ny, 
+                                                    x_points, y_points, vacuum)
         else:
             # Generate images via atom moves
-            self.images = self._gen_atommove_images(base_struct, nx, ny, x_points, y_points, bool(vacuum))
+            self.images = self._gen_atommove_images(base_struct, nx, ny, 
+                                                    x_points, y_points, bool(vacuum))
         return self.images
 
-
-    def relax_images(self, calculator=None, ftol=1e-3, optimiser=BFGSLineSearch, constrain_atoms=True,
+    def relax_images(self, calculator=None, ftol=1e-3, 
+                     optimiser=BFGSLineSearch, constrain_atoms=True,
                      cell_relax=True, logfile=None, steps=200):
         '''
         Utility function to relax gamma surface images using calculator
@@ -325,7 +341,7 @@ class GammaSurface():
             calc = self.calc
 
         if calc is None:
-            raise RuntimeError("No calculator supplied for relaxation")        
+            raise RuntimeError("No calculator supplied for relaxation")
 
         cell_constraint_mask = np.zeros((3, 3))
         if cell_relax:
@@ -345,25 +361,28 @@ class GammaSurface():
             if not opt.converged():
                 raise RuntimeError("An image relaxation failed to converge")
 
-    def get_energy_densities(self, calculator=None, relax=False, **relax_kwargs):
+    def get_energy_densities(self, calculator=None,
+                             relax=False, **relax_kwargs):
         '''
         Get (self.nx, self.ny) grid of gamma surface energies from self.images
 
         Parameters
         ----------
         calculator : ase calculator
-            Calculator to use for finding surface energies (and optionally in the relaxation)
+            Calculator to use for finding surface energies 
+            (and optionally in the relaxation)
         relax : bool
-            Whether to additionally relax the images (through a call to self.relax_images) before finding energies
+            Whether to additionally relax the images 
+            (through a call to self.relax_images) before finding energies
         **relax_kwargs : keyword args
             Extra kwargs to be passed to self.relax_images if relax=True
 
         Returns 
         -------
         Es : np.array
-        (nx, ny) array of energy densities (energy per unit surface area) for the gamma surface, in eV/A**2
+        (nx, ny) array of energy densities (energy per unit surface area) 
+        for the gamma surface, in eV/A**2
         '''
-
 
         if calculator is not None:
             calc = calculator
@@ -377,12 +396,11 @@ class GammaSurface():
         self.surface_area = np.linalg.norm(np.cross(cell[0, :], cell[1, :]))
         self.surface_separation = np.abs(cell[2, 2])
 
-
         Es = np.zeros((self.nx, self.ny))
 
         if relax:
             self.relax_images(calc, **relax_kwargs)
-        
+
         idx = 0
 
         for i in range(self.nx):
@@ -398,13 +416,17 @@ class GammaSurface():
         self.Es = Es
         return Es
 
-    def plot_energy_densities(self, Es=None, ax=None, si=True, interpolation="bicubic"):
+    def plot_energy_densities(self, Es=None, ax=None, 
+                              si=True, interpolation="bicubic"):
         '''
-        Produce a matplotlib plot of the gamma surface energy, from the data gathered in self.generate_images and self.get_surface_energioes
+        Produce a matplotlib plot of the gamma surface energy,
+        from the data gathered in self.generate_images
+        and self.get_surface_energies
 
         Returns a matplotlib fig and ax object
         Es: np.array
-            (nx, ny) array of energy densities. If None, uses self.Es (if populated from self.get_energy_densities())
+            (nx, ny) array of energy densities. If None, uses self.Es
+            (if populated from self.get_energy_densities())
         ax: matplotlib axis object
             Axis to draw plot
         si: bool
@@ -420,7 +442,8 @@ class GammaSurface():
         if Es is None:
             # Should have been populated from self.Es
             # If not, self.get_energy_densities() should have been called
-            raise RuntimeError("No energies to use im plotting! Pass Es=Es, or call self.get_energy_densities().")
+            raise RuntimeError("No energies to use im plotting! Pass Es=Es," +
+                               " or call self.get_energy_densities().")
 
         if si:
             mul = _e * 1e20
@@ -437,7 +460,11 @@ class GammaSurface():
             my_ax = ax
             fig = my_ax.get_figure()
 
-        im = my_ax.imshow(self.Es.T * mul, origin="lower", extent=[0, np.linalg.norm(self.x_disp), 0, np.linalg.norm(self.y_disp)], interpolation=interpolation)
+        im = my_ax.imshow(self.Es.T * mul, origin="lower",
+                          extent=[0, np.linalg.norm(self.x_disp),
+                                  0, np.linalg.norm(self.y_disp)],
+                          interpolation=interpolation)
+
         fig.colorbar(im, ax=ax, label=f"Energy Density ({units})")
 
         my_ax.set_xlim([0, np.linalg.norm(self.x_disp)])
@@ -446,16 +473,18 @@ class GammaSurface():
         my_ax.set_xlabel("Glide in " + self._vec_to_miller(self.surf_directions["x"]) + " ($\AA$)")
         my_ax.set_ylabel("Glide in " + self._vec_to_miller(self.surf_directions["y"]) + " ($\AA$)")
 
-        my_ax.set_title(self._vec_to_miller(self.surf_directions["z"]) + " Gamma Surface\nSurface Separation = {:0.2f} A".format(self.surface_separation))
+        my_ax.set_title(self._vec_to_miller(self.surf_directions["z"]) +
+                        " Gamma Surface\nSurface Separation = {:0.2f} A".format(self.surface_separation))
 
         return fig, my_ax
 
     def show(self, CNA_color=True, plot_energies=False, si=False, **kwargs):
         '''
         Overload of GammaSurface.show()
-        Plots an animation of the stacking fault structure, and optionally the associated 
-        energy densities (requires self.get_energy_densitities() to have been called)
-        
+        Plots an animation of the stacking fault structure,
+        and optionally the associated energy densities
+        (requires self.get_energy_densitities() to have been called)
+
         CNA_color: bool
             Toggle atom colours based on Common Neighbour Analysis (Structure identification)
         plot_energies:
@@ -469,18 +498,17 @@ class GammaSurface():
         import matplotlib.pyplot as plt
         from matplotlib.animation import FuncAnimation
         from matscipy.utils import get_structure_types
-        
-        images = [image.copy() for image in self.images]
 
+        images = [image.copy() for image in self.images]
 
         if CNA_color:
             for system in images:
                 atom_labels, structure_names, colors = get_structure_types(system, 
-                                                                        diamond_structure=True)
+                                                                           diamond_structure=True)
                 atom_colors = [colors[atom_label] for atom_label in atom_labels]
 
                 system.set_array("colors", np.array(atom_colors))
-        
+
         fig, ax = plt.subplots(ncols=2, nrows=2)
         atom_ax1, atom_ax2, atom_ax3, energy_ax = ax.flatten()
 
@@ -510,9 +538,8 @@ class GammaSurface():
                 curr_ax.set_xlabel(self._vec_to_miller(self.surf_directions[xdir]))
                 curr_ax.set_ylabel(self._vec_to_miller(self.surf_directions[ydir]))
 
-
                 if CNA_color:
-                    plot_atoms(atoms, ax=curr_ax, colors=atoms.get_array("colors"), 
+                    plot_atoms(atoms, ax=curr_ax, colors=atoms.get_array("colors"),
                     rotation=rot, **kwargs)
                 else: # default color are jmol (same is nglview)
                     plot_atoms(atoms, ax=curr_ax, rotation=rot, **kwargs)
@@ -520,7 +547,6 @@ class GammaSurface():
                 if keep_lims:
                     curr_ax.set_xlim(xlim)
                     curr_ax.set_ylim(ylim)
-
 
         if plot_energies:
             if self.Es is not None:
@@ -531,7 +557,7 @@ class GammaSurface():
                     Es = self.get_energy_densities()
                 except:
                     raise RuntimeError("Cannot plot energy densities before get_energy_densities is called!")
-                
+
             self.plot_energy_densities(ax=energy_ax, si=si)
         else:
             energy_ax.clear()
@@ -544,7 +570,7 @@ class GammaSurface():
         def drawimage(framedata):
             framenum, atoms = framedata
             # Plot Structure
-            
+
             plot_all_atom_axes(atoms, keep_lims=True)
 
             # Plot energies
@@ -555,7 +581,6 @@ class GammaSurface():
                 self.plot_energy_densities(ax=energy_ax, si=si)
                 pos = self.offsets[framenum]
                 plt.scatter(pos[0], pos[1], marker="x", color="k")
-
 
         animation = FuncAnimation(fig, drawimage, frames=enumerate(images),
                                   save_count=len(images),
@@ -576,14 +601,16 @@ class StackingFault(GammaSurface):
             Number of images
         '''
         return super().generate_images(1, n, *args, **kwargs)
-    
+
     def plot_energy_densities(self, Es=None, ax=None, si=False):
         '''
-        Produce a matplotlib plot of the stacking fault energy, from the data gathered in self.generate_images and self.get_surface_energy
+        Produce a matplotlib plot of the stacking fault energy, 
+        from the data gathered in self.generate_images and self.get_surface_energy
 
         Returns a matplotlib fig and ax object
         Es: np.array
-            (nx, ny) array of energy densities. If None, uses self.Es (if populated from self.get_energy_densities())
+            (nx, ny) array of energy densities. If None, uses self.Es 
+            (if populated from self.get_energy_densities())
         ax: matplotlib axis object
             Axis to draw plot
         si: bool
@@ -597,7 +624,8 @@ class StackingFault(GammaSurface):
         if Es is None:
             # Should have been populated from self.Es
             # If not, self.get_energy_densities() should have been called
-            raise RuntimeError("No energies to use im plotting! Pass Es=Es, or call self.get_energy_densities().")
+            raise RuntimeError("No energies to use im plotting! Pass Es=Es," + 
+                               " or call self.get_energy_densities().")
 
         if si:
             mul = _e * 1e20
@@ -605,7 +633,7 @@ class StackingFault(GammaSurface):
         else:
             mul = 1
             units = "eV/${\AA}^2$"
-        
+
         if ax is None:
 
             fig, my_ax = plt.subplots()
@@ -620,13 +648,14 @@ class StackingFault(GammaSurface):
         title = self._vec_to_miller(self.surf_directions["z"]) + " Stacking Fault\n" + "Surface Separation = {:0.2f}".format(self.surface_separation) + "${\AA}$"
         my_ax.set_title(title)
         return fig, my_ax
-    
+
     def show(self, CNA_color=True, plot_energies=False, si=False, **kwargs):
         '''
         Overload of GammaSurface.show()
-        Plots an animation of the stacking fault structure, and optionally the associated 
+        Plots an animation of the stacking fault structure, 
+        and optionally the associated 
         energy densities (requires self.get_energy_densitities() to have been called)
-        
+
         CNA_color: bool
             Toggle atom colours based on Common Neighbour Analysis (Structure identification)
         plot_energies:
@@ -634,7 +663,8 @@ class StackingFault(GammaSurface):
         si: bool
             Plot energy densities in SI units (J/m^2), or "ASE" units eV/A^2
         rotation: str
-            rotation to apply to the structures, passed directly to ase.visualize.plot.plot_atoms
+            rotation to apply to the structures, 
+            passed directly to ase.visualize.plot.plot_atoms
         **kwargs
             extra kwargs passed to ase.visualize.plot.plot_atoms
         '''
@@ -642,7 +672,7 @@ class StackingFault(GammaSurface):
         import matplotlib.pyplot as plt
         from matplotlib.animation import FuncAnimation
         from matscipy.utils import get_structure_types
-        
+
         images = [image.copy() for image in self.images]
         nims = len(images)
 
@@ -656,11 +686,11 @@ class StackingFault(GammaSurface):
         if CNA_color:
             for system in images:
                 atom_labels, structure_names, colors = get_structure_types(system, 
-                                                                        diamond_structure=True)
+                                                                           diamond_structure=True)
                 atom_colors = [colors[atom_label] for atom_label in atom_labels]
 
                 system.set_array("colors", np.array(atom_colors))
-        
+
         if plot_energies:
             fig, ax = plt.subplots(ncols=2)
             atom_ax, energy_ax = ax
@@ -673,7 +703,7 @@ class StackingFault(GammaSurface):
                     Es = self.get_energy_densities()
                 except:
                     raise RuntimeError("Cannot plot energy densities before get_energy_densities is called!")
-                
+
             self.plot_energy_densities(ax=energy_ax, si=si)
         else:
             fig, atom_ax = plt.subplots()
@@ -684,12 +714,12 @@ class StackingFault(GammaSurface):
 
         xlim = atom_ax.get_xlim()
         ylim = atom_ax.get_ylim()
-        
+
         def drawimage(framedata):
             framenum, atoms = framedata
             # Plot Structure
             atom_ax.clear()
-            
+
             atom_ax.set_xticks([])
             atom_ax.set_yticks([])
 
@@ -710,7 +740,6 @@ class StackingFault(GammaSurface):
                 energy_ax.clear()
                 self.plot_energy_densities(ax=energy_ax, si=si)
                 plt.scatter(np.linalg.norm(self.y_disp) * framenum/(nims-1), Es[0, framenum] * si_fac, marker="x", color="k")
-
 
         animation = FuncAnimation(fig, drawimage, frames=enumerate(images),
                                   save_count=len(images),


### PR DESCRIPTION
Great work on the code and the docs. Here are few things that I fixed to make it even better:

- While build and compare configurations test passes, in fact there was an [error while executing `gamma_surfaces.ipynb` due to execution time limit](https://github.com/libAtoms/matscipy/actions/runs/6961344739/job/18942744108?pr=178#step:5:998). I fixed by adding a [tag to the notebook metadata to extend to the limit](https://myst-nb.readthedocs.io/en/v0.9.0/use/execute.html#execution-timeout). In order to avoid that it is important to build docs locally and look for these errors in the log even if the test is marked as passed.
- I worked a bit on the appearance, for example used admonition for notes and warnings.
- Fixed many flakes on the `gamma_surface.py`. I would recommend you to use a linter to point you to this errors. It is not only about the appearance and readability. There were few declared, but unused variables. I will show them in the code review.

I think now the documentation and the code is in very good shape and I am happy if this is merged. Few enhancements for the future:
- We have a lot of cross references in the plasticity docs. It would be nice to make them links and use the [myst functionality for it](https://myst-parser.readthedocs.io/en/latest/intro.html#cross-referencing)
- For the gamma surface visualisations we could add legend showing what color means in terms of identified strucutre if CNA is enabled or simply colors for the elements if CNA is off. 