### PR TITLE
Disloc quad build cyl refactor

### DIFF
--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2565,8 +2565,18 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
     def _build_supercell(self, targetx, targety):
         '''
-        Build supercell in 2D from self.unit_cell, with target dimensions (targetx, targety).
+        Build supercell in 2D from self.unit_cell, with target dimensions (targetx, targety), specified in Angstrom.
         Supercell is constructed to have cell lengths >= the target value (i.e. cell[0, 0] >= targetx)
+
+        Parameters
+        ----------
+        targetx: float
+            Target length (in Ang) of the cell in the "x" direction (i.e. cell[0, 0])
+        targety: float
+            Target length (in Ang) of the cell in the "y" direction (i.e. cell[1, 0])
+
+        
+        Returns a supercell of self.unit_cell with cell[0, 0] >= targetx and cell[1, 1] >= targety
         '''
 
         base_cell = self.unit_cell

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2448,8 +2448,8 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
         e.g. self.solvers["atomman"] = self.stroh.displacement
         '''
         solver_initters = {
-            "atomman" : self.init_stroh,
-            "adsl" : self.init_anisotropic_dislocation
+            "atomman" : self.init_atomman,
+            "adsl" : self.init_adsl
         }
 
         # Execute init routine
@@ -2503,7 +2503,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
         
         return [self.solvers[method]]
 
-    def init_stroh(self):
+    def init_atomman(self):
         '''
         Init atomman stroh solution solver (requires atomman)
         '''
@@ -2512,7 +2512,7 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
         self.solvers["atomman"] = self.stroh.displacement
 
-    def init_anisotropic_dislocation(self):
+    def init_adsl(self):
         '''
         Init adsl (Anisotropic DiSLocation) solver
         '''

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2560,8 +2560,6 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
 
         idxs = np.argsort(mask_positions, axis=0)
         mask_positions = np.take_along_axis(mask_positions, idxs, axis=0)
-
-        print(mask_positions)
         
         mask = radial_mask_from_polygon2D(sup.get_positions(), mask_positions, radius, inner=True)
 

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2193,7 +2193,7 @@ class AnisotropicDislocation:
         
         
         # define elastic constant in Voigt notation
-        Cijkl = coalesce_elastic_constants(C11, C12, C44, C, standard="Cijkl")
+        Cijkl = coalesce_elastic_constants(C11, C12, C44, C, convention="Cijkl")
 
         # rotate elastic matrix
         cijkl = np.einsum('ig,jh,ghmn,km,ln', \
@@ -2435,8 +2435,8 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
             m : None for m in self.avail_methods
         }
 
-        # Sort out elasticity matrix into 6x6 standard (as we know the system is cubic)
-        self.C = coalesce_elastic_constants(C11, C12, C44, C, standard="Cij")
+        # Sort out elasticity matrix into 6x6 convention (as we know the system is cubic)
+        self.C = coalesce_elastic_constants(C11, C12, C44, C, convention="Cij")
 
     def init_solver(self, method="atomman"):
         '''

--- a/matscipy/dislocation.py
+++ b/matscipy/dislocation.py
@@ -2535,8 +2535,6 @@ class CubicCrystalDislocation(metaclass=ABCMeta):
     @burgers.setter
     def burgers(self, burgers):
         self.burgers_dimensionless = burgers / self.alat
-        if self.stroh is None:
-            self.init_stroh()
 
     def set_burgers(self, burgers):
         self.burgers = burgers

--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -209,13 +209,13 @@ def cubic_to_Voigt_6x6(C11, C12, C44):
                      [  0,  0,  0,  0,C44,  0],
                      [  0,  0,  0,  0,  0,C44]])
 
-def coalesce_elastic_constants(C11=None, C12=None, C44=None, C=None, standard="Cij"):
+def coalesce_elastic_constants(C11=None, C12=None, C44=None, C=None, convention="Cij"):
     '''
-    Convert either all of C11, C12, C44, or 6x6 C, or 3x3x3x3 C to the form defined by standard.
+    Convert either all of C11, C12, C44, or 6x6 C, or 3x3x3x3 C to the form defined by convention.
 
-    standard="cubic": returns C11, C12, C44
-    standard="Cij": returns 6x6 C matrix
-    standard="Cijkl": returns 3x3x3x3 C tensor
+    convention="cubic": returns C11, C12, C44
+    convention="Cij": returns 6x6 C matrix
+    convention="Cijkl": returns 3x3x3x3 C tensor
     
     '''
     # Aim to convert to 3x3x3x3 first, as this contains the maximal information
@@ -252,13 +252,16 @@ def coalesce_elastic_constants(C11=None, C12=None, C44=None, C=None, standard="C
             raise RuntimeError("Elastic Constants not correctly defined. "+
                                 "Pass either C, or all of C11, C12, C44.")
 
-    if standard.lower() == "cijkl":
-        # 3x3x3x3 standard
+    if convention.lower() == "cijkl":
+        # 3x3x3x3 convention
         return Cijkl
-    elif standard.lower() == "cij":
+    elif convention.lower() == "cij":
+        # 6x6 convention
         return full_3x3x3x3_to_Voigt_6x6(Cijkl)
-    elif standard.lower() == "cubic":
+    elif convention.lower() == "cubic":
         return Voigt_6x6_to_cubic(full_3x3x3x3_to_Voigt_6x6(Cijkl))
+    
+    raise ValueError(f"{convention=} not one of 'cubic', 'Cij', 'Cijkl")
 
 def _invariants(s, syy=None, szz=None, syz=None, sxz=None, sxy=None,
                full_3x3_to_Voigt_6=full_3x3_to_Voigt_6_stress):

--- a/matscipy/elasticity.py
+++ b/matscipy/elasticity.py
@@ -209,6 +209,57 @@ def cubic_to_Voigt_6x6(C11, C12, C44):
                      [  0,  0,  0,  0,C44,  0],
                      [  0,  0,  0,  0,  0,C44]])
 
+def coalesce_elastic_constants(C11=None, C12=None, C44=None, C=None, standard="Cij"):
+    '''
+    Convert either all of C11, C12, C44, or 6x6 C, or 3x3x3x3 C to the form defined by standard.
+
+    standard="cubic": returns C11, C12, C44
+    standard="Cij": returns 6x6 C matrix
+    standard="Cijkl": returns 3x3x3x3 C tensor
+    
+    '''
+    # Aim to convert to 3x3x3x3 first, as this contains the maximal information
+    Cijkl = None
+
+    if C is not None:
+        # Prefer to use full matrix, as this contains more info
+        C = np.array(C)
+        if C.shape == (6, 6):
+            Cijkl = Voigt_6x6_to_full_3x3x3x3(C)
+
+
+        elif C.shape == (3, 3, 3, 3):
+            Cijkl = C.copy()
+        else:
+            # C not of the correct shape
+            warnings.warn("C was not the correct shape. Expected shape (6, 6) or (3, 3, 3, 3)")
+        
+        if Cijkl is not None:
+            # Check if C11, C12, or C44 have also been passed
+            # Ignore these inputs, but warn user
+            has_other_elast = [var is not None for var in [C11, C12, C44]]
+
+            if any(has_other_elast):
+                for i, var in enumerate(["C11", "C12", "C44"]):
+                    if has_other_elast[i]:
+                        warnings.warn(f"Ignoring argument {var} as C was passed")
+
+    if Cijkl is None:
+        # Didn't get correct info from C, look at C11, C12, C44
+        if C11 is not None and C12 is not None and C44 is not None:
+            Cijkl = Voigt_6x6_to_full_3x3x3x3(cubic_to_Voigt_6x6(C11, C12, C44))
+        else:
+            raise RuntimeError("Elastic Constants not correctly defined. "+
+                                "Pass either C, or all of C11, C12, C44.")
+
+    if standard.lower() == "cijkl":
+        # 3x3x3x3 standard
+        return Cijkl
+    elif standard.lower() == "cij":
+        return full_3x3x3x3_to_Voigt_6x6(Cijkl)
+    elif standard.lower() == "cubic":
+        return Voigt_6x6_to_cubic(full_3x3x3x3_to_Voigt_6x6(Cijkl))
+
 def _invariants(s, syy=None, szz=None, syz=None, sxz=None, sxy=None,
                full_3x3_to_Voigt_6=full_3x3_to_Voigt_6_stress):
     """

--- a/matscipy/utils.py
+++ b/matscipy/utils.py
@@ -326,7 +326,7 @@ def points_in_polygon2D(p, poly_points):
     points += 1E-3
 
     # Ensure polygon is closed
-    if np.all(poly_points[0, :] != poly_points[-1, :]):
+    if np.any(poly_points[0, :] != poly_points[-1, :]):
         poly_points = np.append(poly_points, poly_points[0, :][np.newaxis, :], axis=0)
 
     npoints = points.shape[0]
@@ -343,7 +343,7 @@ def points_in_polygon2D(p, poly_points):
         if intersections % 2:
             # Even number of intersections, point is inside polygon
             mask[i] = True
-    return mask
+    return mask.astype(bool)
 
 def get_distance_from_polygon2D(test_points:np.array, polygon_points:np.array) -> np.array:
     '''
@@ -407,7 +407,7 @@ def radial_mask_from_polygon2D(test_points:np.array, polygon_points:np.array, ra
     if inner:
         inner_mask = points_in_polygon2D(test_points, polygon_points)
 
-        full_mask = np.logical_or(inner_mask.astype(bool), outer_mask.astype(bool))
+        full_mask = (inner_mask + outer_mask).astype(bool)
     else:
         full_mask = outer_mask.astype(bool)
     return full_mask

--- a/matscipy/utils.py
+++ b/matscipy/utils.py
@@ -334,8 +334,10 @@ def points_in_polygon2D(p, poly_points):
 
     mask = np.zeros(npoints, dtype=bool)
 
-    # Get point that is definitely outside the polygon
-    test_point = np.array([11 * np.max(poly_points[:, 0]), 7 * np.max(poly_points[:, 1])])
+    # Get random point that is definitely outside the polygon
+    a, b = 10 + np.random.random(size=2) * 10
+
+    test_point = np.array([a * np.max(poly_points[:, 0]), b * np.max(poly_points[:, 1])])
 
     for i in range(npoints):
         intersections = 0
@@ -349,6 +351,7 @@ def points_in_polygon2D(p, poly_points):
 def get_distance_from_polygon2D(test_points:np.array, polygon_points:np.array) -> np.array:
     '''
     Get shortest distance between a test point and a polygon defined by polygon_points
+        (i.e. the shortest distance between each point and the lines of the polygon)
     
     Uses formula from https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
 

--- a/matscipy/utils.py
+++ b/matscipy/utils.py
@@ -126,7 +126,7 @@ def complete_basis(v1, v2=None, normalise=False, nmax=5, tol=1E-6):
          (Searches for vectors perpendicular to v1 with small integer indices)
         If v2 is given and is not orthogonal to v1, raises a warning
     normalise: bool
-        return an orthonormal basis, rather than just orthogonal
+        return an float orthonormal basis, rather than integer orthogonal basis
     nmax: int
         Maximum integer index for v2 search
     tol: float
@@ -136,6 +136,7 @@ def complete_basis(v1, v2=None, normalise=False, nmax=5, tol=1E-6):
     -------
     V1, V2, V3: np.arrays
         Complete orthogonal basis, optionally normalised
+        dtype of arrays is int with normalise=False, float with normalise=True
     '''
 
     def _v2_search(v1, nmax, tol):
@@ -159,8 +160,8 @@ def complete_basis(v1, v2=None, normalise=False, nmax=5, tol=1E-6):
 
                     if np.abs(np.dot(v1, test_vec)) < tol:
                         return test_vec
-                    # No nice integer vector found!
-                    raise RuntimeError(f"Could not automatically find an integer basis from basis vector {v1}")
+        # No nice integer vector found!
+        raise RuntimeError(f"Could not automatically find an integer basis from basis vector {v1}")
 
     V1 = np.array(v1).copy().astype(int)
 

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -762,10 +762,10 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
         ccd = cls(a0, C11, C12, C44, symbol="Fe")
         bulk, sc_disloc1 = ccd.build_cylinder(20.0)
         center = np.diag(bulk.cell) / 2
-        stroh_disp = ccd.displacements(bulk.positions, center, use_atomman=True, self_consistent=False)
+        stroh_disp = ccd.displacements(bulk.positions, center, method="atomman", self_consistent=False)
 
         # Get displacements using AnistoropicDislocation class
-        adsl_disp = ccd.displacements(bulk.positions, center, use_atomman=False, self_consistent=False)
+        adsl_disp = ccd.displacements(bulk.positions, center, method="adsl", self_consistent=False)
 
         # Setup the dislcation from the AnistoropicDislocation object
         disloc = bulk.copy()

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -814,7 +814,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
             grad2D_stroh = np.transpose(grad2D_stroh_T)
 
             # Find 2D gradient tensor from AnistoropicDislocation object
-            grad2D_adsl = ccd.ADstroh.deformation_gradient(bulk, center)
+            grad2D_adsl = ccd.ADstroh.deformation_gradient(bulk.positions, center)
 
             # Check gradients
             np.testing.assert_array_almost_equal(grad2D_adsl, grad2D_stroh)

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -436,7 +436,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
             # test the consistency
             # displacement = disloc.positions - bulk.positions
             stroh_displacement = d.displacements(bulk.positions,
-                                                 np.array(disloc.info["core_positions"]),#np.diag(bulk.cell) / 2.0,
+                                                 np.array(disloc.info["core_positions"]),
                                                  self_consistent=d.self_consistent)
 
             displacement = disloc.positions - bulk.positions

--- a/tests/test_dislocation.py
+++ b/tests/test_dislocation.py
@@ -436,7 +436,7 @@ class TestDislocation(matscipytest.MatSciPyTestCase):
             # test the consistency
             # displacement = disloc.positions - bulk.positions
             stroh_displacement = d.displacements(bulk.positions,
-                                                 np.diag(bulk.cell) / 2.0,
+                                                 np.array(disloc.info["core_positions"]),#np.diag(bulk.cell) / 2.0,
                                                  self_consistent=d.self_consistent)
 
             displacement = disloc.positions - bulk.positions

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,81 +10,135 @@ import numpy as np
 test_dir = os.path.dirname(os.path.realpath(__file__))
 
 
-class TestDislocation(matscipytest.MatSciPyTestCase):
-    """Class to store test for utils.py module."""
+class TestUtils(matscipytest.MatSciPyTestCase):
+    """Class to store unittests of utils.py module."""
 
     def test_validate_cubic_cell(self):
-            from ase.build import bulk as build_bulk
-            import warnings
+        from ase.build import bulk as build_bulk
+        import warnings
 
-            warnings.simplefilter("always")
+        warnings.simplefilter("always")
+        
+        bulk_fcc = build_bulk("Cu", crystalstructure="fcc", cubic=True)
+        bulk_bcc = build_bulk("W", crystalstructure="bcc", cubic=True)
+        bulk_dia = build_bulk("C", crystalstructure="diamond", cubic=True)
+
+        bulks = {
+            "fcc": bulk_fcc,
+            "bcc": bulk_bcc,
+            "diamond": bulk_dia
+        }
+
+        axes = np.eye(3).astype(int)
+
+        # Check legacy behaviour works
+        for structure in bulks.keys():
+            bulk = bulks[structure]
+            alat = bulk.cell[0, 0]
+
+            alat_valid, struct = utils_mod.validate_cubic_cell(alat, symbol="Cu", axes=axes, crystalstructure=structure)
+
+            assert alat_valid == alat
+            bpos = np.sort(bulk.get_scaled_positions(), axis=0)
+            spos = np.sort(struct.get_scaled_positions(), axis=0)
+            assert np.allclose(struct.cell[:, :], bulk.cell[:, :])
+            assert np.allclose(bpos, spos)
+
+        # Check new functionality accepted
+        for structure in bulks.keys():
+            bulk = bulks[structure]
+            alat = bulk.cell[0, 0]
+            alat_valid, struct = utils_mod.validate_cubic_cell(bulk, symbol="Cu", axes=axes, crystalstructure=structure)
+
+            assert alat_valid == alat
+            bpos = np.sort(bulk.get_scaled_positions(), axis=0)
+            spos = np.sort(struct.get_scaled_positions(), axis=0)
+            assert np.allclose(struct.cell[:, :], bulk.cell[:, :])
+            assert np.allclose(bpos, spos)
+
+        # Check Fail/Warn states
+        # "a" validation
+        self.assertRaises(TypeError, utils_mod.validate_cubic_cell, "Not a bulk or lattice constant", symbol="Cu", axes=axes, crystalstructure="fcc")
+        
+        # Crystalstructure validation
+        self.assertRaises(ValueError, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure="made up crystalstructure")
+        self.assertRaises(TypeError, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure=["not the ", "right datatype"])
+
+        # Bulk structure validation
+        self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure="bcc")
+        self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure="diamond")
+        self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, bulk_bcc, symbol="Cu", axes=axes, crystalstructure="fcc")
+
+        ats = bulk_fcc.copy()
+        del ats[0]
+        # FCC with vacancy is not bulk FCC!
+        self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, ats, symbol="Cu", axes=axes, crystalstructure="fcc")
+
+        
+        # Test w/ supercells of bulk
+        utils_mod.validate_cubic_cell(bulk_fcc * (2, 2, 2), symbol="Cu", axes=axes, crystalstructure="fcc")
+
+        # Test w/ more complex crystal
+        nacl = build_bulk("NaCl", crystalstructure="zincblende", a=5.8, cubic=True)
+
+        utils_mod.validate_cubic_cell(nacl, symbol="Cu", axes=axes, crystalstructure="diamond")
+
+        warnings.simplefilter("default")
+
+
+    def test_complete_basis(self):
+
+        def test_case(vecs, check=True):
+            tol = 1e-6
+
+            v1, v2, v3 = utils_mod.complete_basis(*vecs, normalise=True)
             
-            bulk_fcc = build_bulk("Cu", crystalstructure="fcc", cubic=True)
-            bulk_bcc = build_bulk("W", crystalstructure="bcc", cubic=True)
-            bulk_dia = build_bulk("C", crystalstructure="diamond", cubic=True)
+            if check:
+                # Check orthogonal basis
+                assert v1.T @ v2 < tol
+                assert v2.T @ v3 < tol
+                assert v3.T @ v1 < tol
 
-            bulks = {
-                "fcc": bulk_fcc,
-                "bcc": bulk_bcc,
-                "diamond": bulk_dia
-            }
+                # Check norms of vecs
+                assert np.linalg.norm(v1) - 1 < tol
+                assert np.linalg.norm(v2) - 1 < tol
+                assert np.linalg.norm(v3) - 1 < tol
 
-            axes = np.eye(3).astype(int)
+                # Check handedness
+                assert np.cross(v1, v2).T @ v3 > 0
 
-            # Check legacy behaviour works
-            for structure in bulks.keys():
-                bulk = bulks[structure]
-                alat = bulk.cell[0, 0]
+                # Check dtype
+                assert v1.dtype == v2.dtype == v3.dtype
+                assert np.issubdtype(v1.dtype, np.floating)
 
-                alat_valid, struct = utils_mod.validate_cubic_cell(alat, symbol="Cu", axes=axes, crystalstructure=structure)
+            v1, v2, v3 = utils_mod.complete_basis(*vecs, normalise=False)
 
-                assert alat_valid == alat
-                bpos = np.sort(bulk.get_scaled_positions(), axis=0)
-                spos = np.sort(struct.get_scaled_positions(), axis=0)
-                assert np.allclose(struct.cell[:, :], bulk.cell[:, :])
-                assert np.allclose(bpos, spos)
+            if check:
+                # Check dtype for non-normalised mode
+                assert v1.dtype == v2.dtype == v3.dtype
+                assert np.issubdtype(v1.dtype, np.integer)
 
-            # Check new functionality accepted
-            for structure in bulks.keys():
-                bulk = bulks[structure]
-                alat = bulk.cell[0, 0]
-                alat_valid, struct = utils_mod.validate_cubic_cell(bulk, symbol="Cu", axes=axes, crystalstructure=structure)
 
-                assert alat_valid == alat
-                bpos = np.sort(bulk.get_scaled_positions(), axis=0)
-                spos = np.sort(struct.get_scaled_positions(), axis=0)
-                assert np.allclose(struct.cell[:, :], bulk.cell[:, :])
-                assert np.allclose(bpos, spos)
+        v1 = np.array([1, 1, 1])
+        v2 = np.array([1, 1, -2])
 
-            # Check Fail/Warn states
+        # Single vec given
+        test_case([v1])
 
-            # "a" validation
-            self.assertRaises(TypeError, utils_mod.validate_cubic_cell, "Not a bulk or lattice constant", symbol="Cu", axes=axes, crystalstructure="fcc")
-            
-            # Crystalstructure validation
-            self.assertRaises(ValueError, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure="made up crystalstructure")
-            self.assertRaises(TypeError, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure=["not the ", "right datatype"])
+        # Two vecs
+        test_case([v1, v2])
 
-            # Bulk structure validation
-            self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure="bcc")
-            self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, bulk_fcc, symbol="Cu", axes=axes, crystalstructure="diamond")
-            self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, bulk_bcc, symbol="Cu", axes=axes, crystalstructure="fcc")
+        v1 = np.array([1, 0, 0])
+        
+        # Non-orthoganal pair
+        # Will fail assertions, so bypass
+        self.assertWarns(RuntimeWarning, test_case, [v1, v2], check=False)
 
-            ats = bulk_fcc.copy()
-            del ats[0]
-            # FCC with vacancy is not bulk FCC!
-            self.assertWarns(UserWarning, utils_mod.validate_cubic_cell, ats, symbol="Cu", axes=axes, crystalstructure="fcc")
 
-            
-            # Test w/ supercells of bulk
-            utils_mod.validate_cubic_cell(bulk_fcc * (2, 2, 2), symbol="Cu", axes=axes, crystalstructure="fcc")
-
-            # Test w/ more complex crystal
-            nacl = build_bulk("NaCl", crystalstructure="zincblende", a=5.8, cubic=True)
-
-            utils_mod.validate_cubic_cell(nacl, symbol="Cu", axes=axes, crystalstructure="diamond")
-
-            warnings.simplefilter("default")
+        v1 = np.array([13, 19, 37])
+        # v1 is three prime numbers, unlikely to have a "neat" orthogonal vector
+        # with max value less than the default nmax
+        self.assertRaises(RuntimeError, test_case, [v1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,5 +140,86 @@ class TestUtils(matscipytest.MatSciPyTestCase):
         # with max value less than the default nmax
         self.assertRaises(RuntimeError, test_case, [v1])
 
+    def test_line_intersect_2d(self):
+
+        p1 = np.array([0, 0])
+        p2 = np.array([2, 0])
+
+        # "Plus" pattern
+        x1 = np.array([1, 1])
+        x2 = np.array([1, -1])
+
+        assert utils_mod.line_intersect_2D(p1, p2, x1, x2) == True
+
+        # Lines don't cross ever
+        x2 = np.array([2, 1])
+        assert utils_mod.line_intersect_2D(p1, p2, x1, x2) == False
+
+        # Finite lines don't meet, but infinite ones would
+        x2 = np.array([2, 0.5])
+        assert utils_mod.line_intersect_2D(p1, p2, x1, x2) == False
+
+        # Lines meet at one of the points
+        x1 = np.array([0, 1])
+        x2 = np.array([0, -1])
+        assert utils_mod.line_intersect_2D(p1, p2, x1, x2) == True
+
+        # Lines end at the same point
+        x2 = p1
+        assert utils_mod.line_intersect_2D(p1, p2, x1, x2) == True
+
+
+    def test_points_in_polygon2D(self):
+
+        # Simple square shape
+        polygon = np.array([
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 1]
+        ])
+
+        inside = np.array([0.5, 0.5])
+        outside = np.array([0.5, 4])
+
+        assert utils_mod.points_in_polygon2D(inside, polygon) == True
+        assert utils_mod.points_in_polygon2D(outside, polygon) == False
+
+        # Complex polygon
+
+        polygon = np.array([
+            [0, 0],
+            [5, 0],
+            [5, 5],
+            [3, 5],
+            [3, 4],
+            [4, 4],
+            [4, 1],
+            [1, 1],
+            [1, 4],
+            [2, 4],
+            [2, 5],
+            [0, 5]
+        ])
+
+        inside = np.array([
+            [0.5, 0.5],
+            [1.5, 4.5]
+        ])
+
+
+        outside = np.array([
+            [6, 0],
+            [0, 6],
+            [2.5, 4.5],
+            [2.5, 2.5],
+            [3.5, 3.5]
+        ])
+
+        assert np.all(utils_mod.points_in_polygon2D(inside, polygon) == True)
+        assert np.all(utils_mod.points_in_polygon2D(outside, polygon) == False)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -236,8 +236,45 @@ class TestUtils(matscipytest.MatSciPyTestCase):
         expected_dists = np.array([1, 0, 0.5])
 
         dists = utils_mod.get_distance_from_polygon2D(points, polygon)
-        
+
         assert np.allclose(dists, expected_dists)
+
+    def test_radial_mask_from_polygon2D(self):
+        polygon = np.array([
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 1]
+        ])
+        
+        # Get 100 random points
+        points = np.random.rand(100, 2)
+
+        # Check that points_in_polygon2D is reproduced
+        assert np.all(utils_mod.radial_mask_from_polygon2D(points, polygon, radius=0.0, inner=True) ==
+                      utils_mod.points_in_polygon2D(points, polygon))
+        
+
+        radius = 0.2
+        inner = False
+
+        points = np.array([
+            [0.5, 0.5], # Inside polygon, outside radius from points/lines
+            [0.5, 0.1], # Close to a line
+            [2, 0.5] # Outside polygon, far from lines
+        ])
+
+        target_mask = np.array([False, True, False])
+
+        assert np.all(utils_mod.radial_mask_from_polygon2D(points, polygon, radius=radius, 
+                                                           inner=inner) == target_mask)
+        
+        inner = True
+        target_mask = np.array([True, True, False])
+        assert np.all(utils_mod.radial_mask_from_polygon2D(points, polygon, radius=radius, 
+                                                           inner=inner) == target_mask)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -219,7 +219,25 @@ class TestUtils(matscipytest.MatSciPyTestCase):
         assert np.all(utils_mod.points_in_polygon2D(inside, polygon) == True)
         assert np.all(utils_mod.points_in_polygon2D(outside, polygon) == False)
 
+    def test_get_distance_from_polygon(self):
+        polygon = np.array([
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 1]
+        ])
 
+        points = np.array([
+            [2, 0], # 1 away from point
+            [0.5, 0], # touching an edge of the polygon
+            [0.5, 0.5] # In the centre, 0.5 from a line
+        ])
+
+        expected_dists = np.array([1, 0, 0.5])
+
+        dists = utils_mod.get_distance_from_polygon2D(points, polygon)
+        
+        assert np.allclose(dists, expected_dists)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Refactor the build_cylinder and displacements methods, to try and increase general applicability of core functions, leading to more reuse of code.

Displacements:
Moved the sum over dislocation cores inside the SCF loop, now the base displacements method can be used to get displacements for arbitrary sets of dislocations

Build_cylinder:
Changed the internals to use a general function for a "cylinder" config of any number of dislocation cores. The full dislocation cylinder routines are now much shorter and more compartmentalised

Quadrupoles:
The quadrupole code now makes better use of the new more general methods, and is much more homogeneous with the two preceding classes. 